### PR TITLE
Add autoresearch evaluator contracts

### DIFF
--- a/services/workflow-api/app/autoresearch.py
+++ b/services/workflow-api/app/autoresearch.py
@@ -18,7 +18,7 @@ from .job_submission import JobSubmitter
 from .persistence import RunStore
 from .registry import WorkflowRegistry
 from .run_artifacts import artifact_run_dir, resolve_run_status
-from .schemas import AutoresearchCampaignCreateRequest, AutoresearchCampaignRecord, AutoresearchCampaignSummaryResponse, AutoresearchDecisionRecord, AutoresearchIterationRecord, AutoresearchSuggestedMutation, DesignDraftRecord, InterpretationRecord, MethodologyDraftRecord, RunCreateRequest, RunRecord
+from .schemas import AutoresearchCampaignCreateRequest, AutoresearchCampaignRecord, AutoresearchCampaignSummaryResponse, AutoresearchDecisionRecord, AutoresearchIterationRecord, AutoresearchSuggestedMutation, DesignDraftRecord, EvaluatorContract, InterpretationRecord, MethodologyDraftRecord, RunCreateRequest, RunRecord
 from .session_helpers import get_required_research_session, touch_research_session
 from .technique_catalog import match_catalog_records_for_intake
 
@@ -68,6 +68,37 @@ def _extract_metric_hints(design: DesignDraftRecord) -> list[str]:
     if not metrics:
         metrics.append('accuracy')
     return _dedupe(metrics)
+
+
+def _metric_direction(metric_name: str) -> str:
+    lowered = metric_name.lower()
+    if lowered in {'loss', 'rmse', 'mae', 'mse', 'error_rate', 'latency', 'peak_vram_gb'} or lowered.endswith('_loss'):
+        return 'minimize'
+    return 'maximize'
+
+
+def _default_evaluator_contract_for_design(design: DesignDraftRecord) -> EvaluatorContract | None:
+    method_spec = design.method_spec
+    if method_spec is not None:
+        if method_spec.evaluator_contract is not None:
+            return method_spec.evaluator_contract
+        metrics = list(method_spec.metrics)
+    else:
+        metrics = []
+    if not metrics:
+        metrics = _extract_metric_hints(design)
+    metrics = _dedupe(metrics)
+    if not metrics:
+        return None
+    primary_metric = metrics[0]
+    return EvaluatorContract(
+        evaluator_type=f'{design.workflow_id}-method-spec-v1',
+        primary_metric={
+            'name': primary_metric,
+            'direction': _metric_direction(primary_metric),
+            'minimum_effect': 0.0,
+        },
+    )
 
 
 def _extract_dataset_hints(design: DesignDraftRecord) -> list[str]:
@@ -353,6 +384,8 @@ def build_autoresearch_campaign(
         max_iterations=request.max_iterations,
         evaluation_policy=request.evaluation_policy,
         mutation_policy=request.mutation_policy,
+        evaluator_contract=request.evaluator_contract,
+        budget_contract=request.budget_contract,
         notes=list(request.notes),
     )
 
@@ -662,21 +695,83 @@ def _load_metrics_payload(settings: Settings, run_id: str) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-def _extract_primary_metric(metrics: dict[str, Any]) -> tuple[str | None, float | None]:
+def resolve_evaluator_contract(
+    methodology: MethodologyDraftRecord | None,
+    campaign: AutoresearchCampaignRecord | None = None,
+) -> EvaluatorContract | None:
+    method_spec = methodology.method_spec if methodology is not None else None
+    if method_spec is not None and method_spec.evaluator_contract is not None:
+        return method_spec.evaluator_contract
+    if campaign is not None:
+        return campaign.evaluator_contract
+    return None
+
+
+def _extract_primary_metric(
+    metrics: dict[str, Any],
+    evaluator_contract: EvaluatorContract | None = None,
+) -> tuple[str | None, float | None, str]:
+    if evaluator_contract is not None and evaluator_contract.primary_metric is not None:
+        name = evaluator_contract.primary_metric.name
+        value = metrics.get(name)
+        if isinstance(value, (int, float)):
+            return name, float(value), 'evaluator_contract'
+        metric_name = metrics.get('metric_name')
+        best_metric = metrics.get('best_metric')
+        if metric_name == name and isinstance(best_metric, (int, float)):
+            return name, float(best_metric), 'evaluator_contract'
+        return name, None, 'evaluator_contract'
     metric_name = metrics.get('metric_name')
     best_metric = metrics.get('best_metric')
     if isinstance(metric_name, str) and isinstance(best_metric, (int, float)):
-        return metric_name, float(best_metric)
+        return metric_name, float(best_metric), 'legacy_payload'
     preferred = ['accuracy', 'f1', 'roc_auc', 'precision', 'recall']
     for key in preferred:
         value = metrics.get(key)
         if isinstance(value, (int, float)):
-            return key, float(value)
+            return key, float(value), 'legacy_inferred'
     numeric_items = [(key, float(value)) for key, value in metrics.items() if isinstance(value, (int, float))]
     if not numeric_items:
-        return (None, None)
+        return (None, None, 'unavailable')
     numeric_items.sort(key=lambda item: item[0])
-    return numeric_items[0]
+    metric_name, metric_value = numeric_items[0]
+    return metric_name, metric_value, 'legacy_inferred'
+
+
+def _evaluate_guardrails(
+    metrics: dict[str, Any],
+    evaluator_contract: EvaluatorContract | None,
+) -> list[dict[str, Any]]:
+    if evaluator_contract is None:
+        return []
+    results: list[dict[str, Any]] = []
+    for guardrail in evaluator_contract.guardrails:
+        value = metrics.get(guardrail.name)
+        result: dict[str, Any] = {
+            'metric_name': guardrail.name,
+            'direction': guardrail.direction,
+            'required': guardrail.required,
+            'minimum': guardrail.minimum,
+            'maximum': guardrail.maximum,
+            'value': value if isinstance(value, (int, float, bool)) else None,
+            'passed': True,
+            'detail': 'guardrail satisfied',
+        }
+        if not isinstance(value, (int, float)):
+            result['passed'] = not guardrail.required
+            result['detail'] = 'required guardrail metric missing' if guardrail.required else 'optional guardrail metric missing'
+            results.append(result)
+            continue
+        numeric_value = float(value)
+        result['value'] = numeric_value
+        if guardrail.minimum is not None and numeric_value < guardrail.minimum:
+            result['passed'] = False
+            result['detail'] = f'value is below minimum {guardrail.minimum}'
+        if guardrail.maximum is not None and numeric_value > guardrail.maximum:
+            result['passed'] = False
+            result['detail'] = f'value is above maximum {guardrail.maximum}'
+        results.append(result)
+    return results
 
 
 def summarize_iteration_run(
@@ -684,16 +779,27 @@ def summarize_iteration_run(
     *,
     settings: Settings,
     submitter: JobSubmitter,
+    evaluator_contract: EvaluatorContract | None = None,
 ) -> dict[str, Any]:
     resolved = resolve_run_status(record, settings, submitter)
     metrics = _load_metrics_payload(settings, record.run_id)
-    metric_name, metric_value = _extract_primary_metric(metrics)
+    metric_name, metric_value, metric_source = _extract_primary_metric(metrics, evaluator_contract)
+    direction = (
+        evaluator_contract.primary_metric.direction
+        if evaluator_contract is not None and evaluator_contract.primary_metric is not None
+        else None
+    )
     summary: dict[str, Any] = {
         'run_status': resolved.status,
         'run_detail': resolved.detail,
         'primary_metric_name': metric_name,
         'primary_metric_value': metric_value,
+        'primary_metric_source': metric_source,
+        'primary_metric_direction': direction,
     }
+    if evaluator_contract is not None:
+        summary['evaluator_type'] = evaluator_contract.evaluator_type
+        summary['guardrails'] = _evaluate_guardrails(metrics, evaluator_contract)
     if metrics:
         summary['metrics'] = metrics
     return summary
@@ -702,10 +808,17 @@ def summarize_iteration_run(
 def build_iteration_comparison(
     child_summary: dict[str, Any],
     parent_summary: dict[str, Any] | None,
+    evaluator_contract: EvaluatorContract | None = None,
 ) -> dict[str, Any]:
+    primary_metric = evaluator_contract.primary_metric if evaluator_contract is not None else None
+    direction = primary_metric.direction if primary_metric is not None else child_summary.get('primary_metric_direction')
+    minimum_effect = primary_metric.minimum_effect if primary_metric is not None else 0.0
     comparison: dict[str, Any] = {
         'baseline_available': parent_summary is not None,
         'metric_name': child_summary.get('primary_metric_name'),
+        'direction': direction,
+        'minimum_effect': minimum_effect,
+        'comparable': False,
     }
     if parent_summary is None:
         comparison['detail'] = 'no prior scored baseline is available'
@@ -718,9 +831,13 @@ def build_iteration_comparison(
     if not isinstance(child_value, (int, float)) or not isinstance(parent_value, (int, float)):
         comparison['detail'] = 'numeric metrics unavailable for automatic comparison'
         return comparison
+    raw_delta = float(child_value) - float(parent_value)
+    normalized_delta = raw_delta if direction != 'minimize' else -raw_delta
     comparison['baseline_value'] = parent_value
     comparison['candidate_value'] = child_value
-    comparison['delta'] = round(float(child_value) - float(parent_value), 6)
+    comparison['delta'] = round(raw_delta, 6)
+    comparison['normalized_delta'] = round(normalized_delta, 6)
+    comparison['comparable'] = True
     comparison['detail'] = 'numeric comparison computed'
     return comparison
 
@@ -729,20 +846,33 @@ def build_decision(
     iteration: AutoresearchIterationRecord,
     child_summary: dict[str, Any],
     comparison_summary: dict[str, Any],
+    evaluator_contract: EvaluatorContract | None = None,
 ) -> tuple[str, str]:
     run_status = str(child_summary.get('run_status', 'unknown'))
     if run_status in {'failed', 'rejected'}:
         return ('discard', f'Run ended in terminal failure state: {run_status}.')
-    delta = comparison_summary.get('delta')
+    if evaluator_contract is None or evaluator_contract.primary_metric is None:
+        return ('escalate_for_review', 'Automatic scientific decisions require an approved evaluator contract with a primary metric.')
+    failed_guardrails = [
+        guardrail
+        for guardrail in child_summary.get('guardrails', [])
+        if isinstance(guardrail, dict) and guardrail.get('passed') is False
+    ]
+    if failed_guardrails:
+        names = ', '.join(str(item.get('metric_name')) for item in failed_guardrails[:3])
+        return ('escalate_for_review', f'Candidate violates evaluator guardrail(s): {names}.')
+    delta = comparison_summary.get('normalized_delta')
     metric_name = comparison_summary.get('metric_name')
+    direction = comparison_summary.get('direction') or evaluator_contract.primary_metric.direction
+    minimum_effect = float(comparison_summary.get('minimum_effect') or evaluator_contract.primary_metric.minimum_effect)
     if isinstance(delta, (int, float)) and metric_name:
-        if delta > 0.01:
-            return ('keep', f'Candidate improved {metric_name} by {delta:.4f} over the baseline.')
-        if delta < -0.01:
-            return ('discard', f'Candidate regressed {metric_name} by {abs(delta):.4f} relative to the baseline.')
-        return ('escalate_for_review', f'Candidate changed {metric_name} by {delta:.4f}; review is required.')
+        if delta >= minimum_effect:
+            return ('keep', f'Candidate improved {metric_name} by {delta:.4f} over the baseline under the {direction} contract.')
+        if delta <= -minimum_effect:
+            return ('discard', f'Candidate regressed {metric_name} by {abs(delta):.4f} relative to the baseline under the {direction} contract.')
+        return ('escalate_for_review', f'Candidate changed {metric_name} by {delta:.4f}; minimum effect is {minimum_effect:.4f}.')
     if run_status == 'succeeded' and isinstance(child_summary.get('primary_metric_value'), (int, float)):
-        return ('keep', 'Candidate produced a successful bounded run with scored metrics, but no trusted baseline was available.')
+        return ('keep', 'Candidate produced the first successful bounded run under the approved evaluator contract.')
     return ('escalate_for_review', 'Insufficient evidence for an automatic keep/discard decision.')
 
 
@@ -761,6 +891,7 @@ def build_model_comparison_rows(
         models = draft.candidate_models or draft.architectures or draft.baselines
         metric_name = iteration.score_summary.get('primary_metric_name')
         metric_value = iteration.score_summary.get('primary_metric_value')
+        metric_direction = iteration.score_summary.get('primary_metric_direction')
         metrics_payload = iteration.score_summary.get('metrics', {})
         best_model = metrics_payload.get('best_model') if isinstance(metrics_payload, dict) else None
         technique_components = metrics_payload.get('technique_components') if isinstance(metrics_payload, dict) else None
@@ -774,6 +905,7 @@ def build_model_comparison_rows(
                 'best_model': best_model,
                 'primary_metric_name': metric_name,
                 'primary_metric_value': metric_value,
+                'primary_metric_direction': metric_direction,
                 'technique_components': technique_components if isinstance(technique_components, dict) else {},
                 'readiness_components': readiness_components if isinstance(readiness_components, dict) else {},
                 'decision': decision.decision_type if decision is not None else iteration.decision,
@@ -785,7 +917,11 @@ def build_model_comparison_rows(
     rows.sort(
         key=lambda row: (
             0 if row.get('decision') == 'keep' else 1,
-            -(float(row['primary_metric_value']) if isinstance(row.get('primary_metric_value'), (int, float)) else -1e9),
+            (
+                float(row['primary_metric_value'])
+                if row.get('primary_metric_direction') == 'minimize' and isinstance(row.get('primary_metric_value'), (int, float))
+                else -(float(row['primary_metric_value']) if isinstance(row.get('primary_metric_value'), (int, float)) else -1e9)
+            ),
             row['iteration_id'],
         )
     )
@@ -806,7 +942,13 @@ def refresh_campaign_iterations(
         if run is None:
             refreshed.append(iteration)
             continue
-        score_summary = summarize_iteration_run(run, settings=settings, submitter=submitter)
+        draft = store.get_methodology_draft(iteration.child_methodology_draft_id)
+        score_summary = summarize_iteration_run(
+            run,
+            settings=settings,
+            submitter=submitter,
+            evaluator_contract=resolve_evaluator_contract(draft, campaign),
+        )
         run_status = str(score_summary.get('run_status', 'unknown'))
         next_status = iteration.status
         if iteration.decision is None:
@@ -1408,6 +1550,8 @@ def build_campaign_and_seed(
         source_design_id=design.design_id,
         objective=objective,
     )
+    if campaign.evaluator_contract is None:
+        campaign = campaign.model_copy(update={'evaluator_contract': _default_evaluator_contract_for_design(design)})
     seed = build_seed_methodology_draft(campaign, design, workflow)
     campaign = campaign.model_copy(
         update={

--- a/services/workflow-api/app/autoresearch_routes.py
+++ b/services/workflow-api/app/autoresearch_routes.py
@@ -19,6 +19,7 @@ from .autoresearch import (
     get_next_launchable_methodology_draft,
     get_required_campaign,
     methodology_to_run_request,
+    resolve_evaluator_contract,
     summarize_campaign,
     summarize_iteration_run,
     write_autoresearch_notebook_draft,
@@ -77,7 +78,9 @@ def register_autoresearch_routes(
         child_run = store.get_run(iteration.run_id)
         if child_run is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='run not found for iteration')
-        child_summary = summarize_iteration_run(child_run, settings=settings, submitter=submitter)
+        child_draft = store.get_methodology_draft(iteration.child_methodology_draft_id)
+        evaluator_contract = resolve_evaluator_contract(child_draft, campaign)
+        child_summary = summarize_iteration_run(child_run, settings=settings, submitter=submitter, evaluator_contract=evaluator_contract)
         if iteration.decision is not None:
             existing = next(
                 (
@@ -109,9 +112,15 @@ def register_autoresearch_routes(
         if baseline_iteration is not None:
             baseline_run = store.get_run(baseline_iteration.run_id)
             if baseline_run is not None:
-                parent_summary = summarize_iteration_run(baseline_run, settings=settings, submitter=submitter)
-        comparison_summary = build_iteration_comparison(child_summary, parent_summary)
-        decision_type, rationale = build_decision(iteration, child_summary, comparison_summary)
+                baseline_draft = store.get_methodology_draft(baseline_iteration.child_methodology_draft_id)
+                parent_summary = summarize_iteration_run(
+                    baseline_run,
+                    settings=settings,
+                    submitter=submitter,
+                    evaluator_contract=resolve_evaluator_contract(baseline_draft, campaign) or evaluator_contract,
+                )
+        comparison_summary = build_iteration_comparison(child_summary, parent_summary, evaluator_contract=evaluator_contract)
+        decision_type, rationale = build_decision(iteration, child_summary, comparison_summary, evaluator_contract=evaluator_contract)
         decision = AutoresearchDecisionRecord(
             decision_id=uuid4().hex,
             campaign_id=campaign.campaign_id,
@@ -137,7 +146,6 @@ def register_autoresearch_routes(
         )
         store.save_autoresearch_iteration(updated_iteration)
 
-        child_draft = store.get_methodology_draft(iteration.child_methodology_draft_id)
         if child_draft is not None:
             child_draft = child_draft.model_copy(
                 update={
@@ -289,7 +297,12 @@ def register_autoresearch_routes(
             run_purpose='autoresearch-validation',
             session_id=campaign.session_id,
         )
-        score_summary = summarize_iteration_run(run, settings=settings, submitter=submitter)
+        score_summary = summarize_iteration_run(
+            run,
+            settings=settings,
+            submitter=submitter,
+            evaluator_contract=resolve_evaluator_contract(draft, campaign),
+        )
         iteration = AutoresearchIterationRecord(
             iteration_id=uuid4().hex,
             campaign_id=campaign.campaign_id,
@@ -381,7 +394,12 @@ def register_autoresearch_routes(
                 run_purpose='autoresearch-validation',
                 session_id=campaign.session_id,
             )
-            score_summary = summarize_iteration_run(run, settings=settings, submitter=submitter)
+            score_summary = summarize_iteration_run(
+                run,
+                settings=settings,
+                submitter=submitter,
+                evaluator_contract=resolve_evaluator_contract(draft, campaign),
+            )
             iteration = AutoresearchIterationRecord(
                 iteration_id=uuid4().hex,
                 campaign_id=campaign.campaign_id,
@@ -481,7 +499,13 @@ def register_autoresearch_routes(
             run = store.get_run(iteration.run_id)
             if run is None:
                 continue
-            summary = summarize_iteration_run(run, settings=settings, submitter=submitter)
+            draft = store.get_methodology_draft(iteration.child_methodology_draft_id)
+            summary = summarize_iteration_run(
+                run,
+                settings=settings,
+                submitter=submitter,
+                evaluator_contract=resolve_evaluator_contract(draft, campaign),
+            )
             if str(summary.get('run_status')) == 'succeeded' and (
                 iteration.decision is None or (
                     iteration.decision == 'escalate_for_review'

--- a/services/workflow-api/app/execution_routes.py
+++ b/services/workflow-api/app/execution_routes.py
@@ -230,11 +230,15 @@ def register_execution_routes(
             notes=request.notes,
         )
 
-    def enrich_inputs_with_method_context(design) -> dict[str, Any]:
+    def filter_inputs_for_workflow(inputs: dict[str, Any], workflow) -> dict[str, Any]:
+        allowed_inputs = {item.name for item in workflow.required_inputs}
+        return {key: value for key, value in inputs.items() if key in allowed_inputs}
+
+    def enrich_inputs_with_method_context(design, workflow) -> dict[str, Any]:
         method_spec = getattr(design, 'method_spec', None)
         inputs = dict(method_spec.execution_inputs) if method_spec is not None else dict(design.declared_inputs)
         if method_spec is None:
-            return inputs
+            return filter_inputs_for_workflow(inputs, workflow)
         if method_spec.candidate_models:
             inputs['technique_candidate_models'] = list(method_spec.candidate_models)
         if method_spec.baseline_models:
@@ -245,7 +249,7 @@ def register_execution_routes(
             inputs['technique_task_type'] = method_spec.task_type
         if method_spec.metrics:
             inputs['technique_metrics'] = list(method_spec.metrics)
-        return inputs
+        return filter_inputs_for_workflow(inputs, workflow)
 
     def resolve_requested_models(requested_models: list[str], workflow) -> list[str]:
         allowed = list(workflow.allowed_models or [])
@@ -477,7 +481,7 @@ def register_execution_routes(
         request = RunCreateRequest(
             workflow_id=design.workflow_id,
             objective=design.objective,
-            inputs=enrich_inputs_with_method_context(design),
+            inputs=enrich_inputs_with_method_context(design, workflow),
             models=resolve_requested_models(
                 (method_spec.candidate_models if method_spec is not None and method_spec.candidate_models else design.candidate_models)
                 or workflow.allowed_models[:1],
@@ -517,7 +521,7 @@ def register_execution_routes(
         request = RunCreateRequest(
             workflow_id=design.workflow_id,
             objective=design.objective,
-            inputs=enrich_inputs_with_method_context(design),
+            inputs=enrich_inputs_with_method_context(design, workflow),
             models=resolve_requested_models(
                 (method_spec.candidate_models if method_spec is not None and method_spec.candidate_models else design.candidate_models)
                 or workflow.allowed_models[:1],

--- a/services/workflow-api/app/literature_routes.py
+++ b/services/workflow-api/app/literature_routes.py
@@ -123,7 +123,7 @@ def register_literature_routes(
             chosen_paper_id=chosen_paper.paper_id,
             pipeline=pipeline,
             warnings=warnings,
-            next_action='report-ready' if pipeline.next_action == 'report-ready' else 'pipeline-started',
+            next_action=pipeline.next_action,
         )
 
     @app.post('/research-sessions', response_model=ResearchSessionRecord, status_code=status.HTTP_201_CREATED)

--- a/services/workflow-api/app/main.py
+++ b/services/workflow-api/app/main.py
@@ -29,7 +29,6 @@ from .paper_pipeline import (
 )
 from .persistence import RunStore, create_run_store
 from .registry import WorkflowRegistry
-from .source_documents import build_source_fetch_candidates
 from .schedule_routes import register_schedule_routes
 from .source_documents import ingest_source_document, register_source_document_routes
 from .technique_catalog import register_technique_catalog_routes
@@ -359,10 +358,7 @@ def build_fresh_paper_request_from_problem(
     chosen_paper: ResearchProblemPaperCandidate,
     selected_track_ids: list[str],
 ) -> FreshPaperPipelineRequest:
-    paper_ref = (
-        next(iter(build_source_fetch_candidates(chosen_paper.official_page, chosen_paper.pdf_url)), None)
-        or chosen_paper.paper_id
-    )
+    paper_ref = chosen_paper.official_page or chosen_paper.pdf_url or chosen_paper.paper_id
     notes = [f"Source title: {chosen_paper.title.strip()}"]
     if chosen_paper.abstract_excerpt:
         notes.append(chosen_paper.abstract_excerpt.strip())
@@ -505,10 +501,7 @@ def build_intake_request_from_problem_candidate(
             return
         target.append(value)
 
-    paper_ref = (
-        next(iter(build_source_fetch_candidates(candidate.official_page, candidate.pdf_url)), None)
-        or candidate.paper_id
-    )
+    paper_ref = candidate.official_page or candidate.pdf_url or candidate.paper_id
     manual_source = 'manual' in candidate.tags or 'manual' in candidate.tracks
     notes: list[str] = []
     append_unique_note(notes, f'Source title: {candidate.title.strip()}')
@@ -1087,6 +1080,11 @@ def enrich_run_inputs_with_method_context(design: DesignDraftRecord) -> dict[str
     if method_spec.metrics:
         inputs['technique_metrics'] = list(method_spec.metrics)
     return inputs
+
+
+def filter_run_inputs_for_workflow(inputs: dict[str, Any], workflow: WorkflowRegistryEntry) -> dict[str, Any]:
+    allowed_inputs = {item.name for item in workflow.required_inputs}
+    return {key: value for key, value in inputs.items() if key in allowed_inputs}
 
 
 def resolve_run_requested_models(requested_models: list[str], workflow: WorkflowRegistryEntry) -> list[str]:
@@ -1694,7 +1692,7 @@ def create_app(
         run_request = RunCreateRequest(
             workflow_id=design.workflow_id,
             objective=design.objective,
-            inputs=enrich_run_inputs_with_method_context(design),
+            inputs=filter_run_inputs_for_workflow(enrich_run_inputs_with_method_context(design), workflow),
             models=resolve_run_requested_models(
                 (
                     method_spec.candidate_models

--- a/services/workflow-api/app/paper_pipeline.py
+++ b/services/workflow-api/app/paper_pipeline.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 from .config import Settings
-from .job_submission import resolve_dataset_uri
 from .schemas import DesignDraftRecord, FreshPaperPipelineRequest, IntakeCreateRequest, IntakeRecord, InterpretationRecord
 
 
@@ -67,7 +66,7 @@ def auto_resolve_pipeline_design_inputs_impl(
             else:
                 dataset_uri = 's3://datasets/paper-derived/train.csv'
                 review_notes.append('Auto-resolved literature dataset_uri to bounded paper-derived dataset placeholder.')
-        resolved_inputs['dataset_uri'] = resolve_dataset_uri(dataset_uri, settings)
+        resolved_inputs['dataset_uri'] = dataset_uri
     elif design.workflow_id == 'replication-lite':
         repository_url = resolve_replication_repository_url(intake)
         if repository_url:
@@ -79,7 +78,6 @@ def auto_resolve_pipeline_design_inputs_impl(
         else:
             resolved_inputs['dataset_uri'] = 's3://datasets/replication-lite/input.csv'
             review_notes.append('Auto-resolved replication dataset_uri to bounded default input.')
-        resolved_inputs['dataset_uri'] = resolve_dataset_uri(resolved_inputs['dataset_uri'], settings)
         if interpretation.evaluation_targets:
             resolved_inputs['evaluation_target'] = interpretation.evaluation_targets[0]
             review_notes.append('Auto-resolved evaluation_target from interpretation output.')

--- a/services/workflow-api/app/schemas.py
+++ b/services/workflow-api/app/schemas.py
@@ -1355,23 +1355,6 @@ class ResearchSessionNextCommandResponse(BaseModel):
     launches_started: int = 0
 
 
-class StartLiteratureSearchRequest(BaseModel):
-    model_config = ConfigDict(extra='forbid')
-
-    session_id: str = Field(min_length=1)
-    max_candidate_papers: int = Field(default=3, ge=1, le=25)
-    priorities: list[str] = Field(default_factory=list)
-    submitted_by: str | None = None
-
-
-class StartLiteratureSearchResponse(BaseModel):
-    model_config = ConfigDict(extra='forbid')
-
-    session: ResearchSessionRecord
-    problem_id: str
-    problem_statement: str
-
-
 class PromotePaperToIntakeRequest(BaseModel):
     model_config = ConfigDict(extra='forbid')
 

--- a/services/workflow-api/app/schemas.py
+++ b/services/workflow-api/app/schemas.py
@@ -576,6 +576,42 @@ class TechniqueKnowledgeRecord(BaseModel):
     source_scope: str = 'paper'
 
 
+class PrimaryMetricContract(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    name: str = Field(min_length=1)
+    direction: Literal['maximize', 'minimize'] = 'maximize'
+    minimum_effect: float = Field(default=0.0, ge=0.0)
+
+
+class GuardrailMetricContract(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    name: str = Field(min_length=1)
+    direction: Literal['maximize', 'minimize'] = 'maximize'
+    minimum: float | None = None
+    maximum: float | None = None
+    required: bool = False
+
+
+class EvaluatorContract(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    evaluator_type: str = Field(default='generic', min_length=1)
+    primary_metric: PrimaryMetricContract | None = None
+    guardrails: list[GuardrailMetricContract] = Field(default_factory=list)
+    uncertainty: dict[str, Any] = Field(default_factory=dict)
+
+
+class BudgetContract(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    budget_mode: Literal['wallclock', 'training_exposure', 'fixed_steps', 'manual'] = 'manual'
+    max_wallclock_minutes: int | None = Field(default=None, ge=1)
+    max_samples_seen: int | None = Field(default=None, ge=1)
+    max_optimizer_steps: int | None = Field(default=None, ge=1)
+
+
 class MethodSpecRecord(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
@@ -593,6 +629,8 @@ class MethodSpecRecord(BaseModel):
     resource_profile: str | None = None
     execution_inputs: dict[str, Any] = Field(default_factory=dict)
     mutation_axes: list[str] = Field(default_factory=list)
+    evaluator_contract: EvaluatorContract | None = None
+    budget_contract: BudgetContract | None = None
     run_readiness: Literal['ready', 'needs_review', 'blocked'] = 'needs_review'
     blocking_reasons: list[str] = Field(default_factory=list)
 
@@ -728,6 +766,8 @@ class AutoresearchCampaignRecord(BaseModel):
     max_iterations: int = Field(default=3, ge=1, le=25)
     evaluation_policy: str
     mutation_policy: str
+    evaluator_contract: EvaluatorContract | None = None
+    budget_contract: BudgetContract | None = None
     notes: list[str] = Field(default_factory=list)
 
 
@@ -1146,6 +1186,8 @@ class AutoresearchCampaignCreateRequest(BaseModel):
     max_iterations: int = Field(default=3, ge=1, le=25)
     evaluation_policy: str = 'metrics-first-v1'
     mutation_policy: str = 'methodology-variants-v1'
+    evaluator_contract: EvaluatorContract | None = None
+    budget_contract: BudgetContract | None = None
     notes: list[str] = Field(default_factory=list)
 
     @field_validator('notes')

--- a/services/workflow-api/app/stage_design.py
+++ b/services/workflow-api/app/stage_design.py
@@ -21,6 +21,16 @@ LOGGER = logging.getLogger(__name__)
 UNRESOLVED_PREFIX = 'UNRESOLVED_'
 
 
+def looks_like_dataset_uri(value: str) -> bool:
+    text = value.strip()
+    lowered = text.lower()
+    if lowered.startswith(('s3://', 'file://', '/mnt/')):
+        return True
+    if not lowered.startswith(('http://', 'https://')):
+        return False
+    return bool(re.search(r'\.(csv|tsv|jsonl|json|parquet|arrow|feather|npy|npz)(?:[?#].*)?$', lowered))
+
+
 def build_replicability_assessment(
     interpretation: InterpretationRecord,
     registry: WorkflowRegistry,
@@ -240,9 +250,16 @@ def derive_design_from_intake(intake: IntakeRecord, workflow: WorkflowRegistryEn
     declared_inputs: dict[str, Any] = {}
     design_notes: list[str] = []
 
-    explicit_dataset_uri = None
+    explicit_dataset_uri = next(
+        (
+            note.split(':', 1)[1].strip()
+            for note in intake.notes
+            if isinstance(note, str) and note.startswith('Dataset URI:')
+        ),
+        None,
+    )
     concrete_dataset_match = re.search(r'(s3://\S+|file://\S+|/mnt/\S+)', intake.raw_request)
-    if concrete_dataset_match:
+    if explicit_dataset_uri is None and concrete_dataset_match:
         explicit_dataset_uri = concrete_dataset_match.group(1).rstrip('.,);')
     explicit_dataset_uri = explicit_dataset_uri or next(
         (
@@ -250,13 +267,7 @@ def derive_design_from_intake(intake: IntakeRecord, workflow: WorkflowRegistryEn
             for ref in intake.source_refs
             if isinstance(ref, str)
             and ref.strip()
-            and (
-                ref.startswith('http://')
-                or ref.startswith('https://')
-                or ref.startswith('s3://')
-                or ref.startswith('file://')
-                or ref.startswith('/mnt/')
-            )
+            and looks_like_dataset_uri(ref)
         ),
         None,
     )

--- a/services/workflow-api/app/stage_design.py
+++ b/services/workflow-api/app/stage_design.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import json
 import logging
+import re
 from typing import Any
 from urllib.parse import urlparse
 from urllib import error as urllib_error
@@ -239,7 +240,11 @@ def derive_design_from_intake(intake: IntakeRecord, workflow: WorkflowRegistryEn
     declared_inputs: dict[str, Any] = {}
     design_notes: list[str] = []
 
-    explicit_dataset_uri = next(
+    explicit_dataset_uri = None
+    concrete_dataset_match = re.search(r'(s3://\S+|file://\S+|/mnt/\S+)', intake.raw_request)
+    if concrete_dataset_match:
+        explicit_dataset_uri = concrete_dataset_match.group(1).rstrip('.,);')
+    explicit_dataset_uri = explicit_dataset_uri or next(
         (
             ref
             for ref in intake.source_refs

--- a/services/workflow-api/app/stage_inference.py
+++ b/services/workflow-api/app/stage_inference.py
@@ -502,7 +502,7 @@ def infer_dataset_uri_hint(intake: IntakeRecord) -> str | None:
     match = re.search(r'(s3://\S+|file://\S+|/mnt/\S+)', text)
     if match:
         return match.group(1).rstrip('.,);')
-    match = re.search(r'(https?://\S+)', text)
+    match = re.search(r'(https?://\S+\.(?:csv|tsv|jsonl|json|parquet|arrow|feather|npy|npz)(?:[?#]\S*)?)', text, flags=re.IGNORECASE)
     if match:
         return match.group(1).rstrip('.,);')
     lowered = text.lower()

--- a/services/workflow-api/app/stage_inference.py
+++ b/services/workflow-api/app/stage_inference.py
@@ -499,7 +499,10 @@ def infer_split_strategies(
 
 def infer_dataset_uri_hint(intake: IntakeRecord) -> str | None:
     text = ' '.join([intake.raw_request, intake.normalized_summary, *intake.notes, *intake.source_refs])
-    match = re.search(r'(https?://\S+|s3://\S+|file://\S+|/mnt/\S+)', text)
+    match = re.search(r'(s3://\S+|file://\S+|/mnt/\S+)', text)
+    if match:
+        return match.group(1).rstrip('.,);')
+    match = re.search(r'(https?://\S+)', text)
     if match:
         return match.group(1).rstrip('.,);')
     lowered = text.lower()

--- a/services/workflow-api/app/transition_routes.py
+++ b/services/workflow-api/app/transition_routes.py
@@ -24,12 +24,10 @@ from .schemas import (
     PromotePaperToIntakeResponse,
     RunCreateRequest,
     RunRecord,
-    StartLiteratureSearchRequest,
-    StartLiteratureSearchResponse,
     CreateValidationRunRequest,
     CreateValidationRunResponse,
 )
-from .session_helpers import build_research_problem_request_from_session, get_required_research_session, touch_research_session
+from .session_helpers import touch_research_session
 
 
 def build_intake_request_from_problem_candidate(
@@ -156,22 +154,6 @@ def register_transitions_routes(
     create_run_record_impl: Callable[..., RunRecord],
     build_research_problem_record_impl: Callable[..., Any],
 ) -> None:
-    @app.post('/transitions/start-literature-search', response_model=StartLiteratureSearchResponse)
-    def start_literature_search(request: StartLiteratureSearchRequest) -> StartLiteratureSearchResponse:
-        session = get_required_research_session(store, request.session_id)
-        problem_request = build_research_problem_request_from_session(session, settings)
-        problem_request.max_candidate_papers = request.max_candidate_papers
-        problem_request.priorities = request.priorities or problem_request.priorities
-        problem_record = build_research_problem_record_impl(problem_request, settings, session.session_id)
-        store.save_research_problem(problem_record)
-        updated_session = touch_research_session(store, session.session_id, latest_problem_id=problem_record.problem_id)
-        
-        return StartLiteratureSearchResponse(
-            session=updated_session,
-            problem_id=problem_record.problem_id,
-            problem_statement=problem_record.problem_statement,
-        )
-
     @app.post('/transitions/promote-paper-to-intake', response_model=PromotePaperToIntakeResponse)
     def promote_paper_to_intake(request: PromotePaperToIntakeRequest) -> PromotePaperToIntakeResponse:
         queue_record = store.get_paper_intake_queue(request.queue_id)

--- a/services/workflow-api/tests/test_api.py
+++ b/services/workflow-api/tests/test_api.py
@@ -13,7 +13,7 @@ from app.config import Settings
 import app.autoresearch as autoresearch_module
 import app.main as main_module
 import app.source_documents as source_documents
-from app.schemas import AutoresearchDecisionRecord, AutoresearchIterationRecord
+from app.schemas import AutoresearchDecisionRecord, AutoresearchIterationRecord, EvaluatorContract
 from app.stage_interpretation import build_interpretation_record_from_agent_draft, validate_interpretation_agent_draft
 from app.main import create_app
 from app.persistence import InMemoryRunStore
@@ -4972,6 +4972,10 @@ def test_autoresearch_campaign_happy_path(tmp_path) -> None:
             'source_design_id': design_payload['design_id'],
             'objective': 'Compare a small set of approved tabular methodology variants on Titanic.',
             'max_iterations': 2,
+            'evaluator_contract': {
+                'evaluator_type': 'titanic_tabular_v1',
+                'primary_metric': {'name': 'accuracy', 'direction': 'maximize', 'minimum_effect': 0.01},
+            },
         },
     )
     assert campaign.status_code == 201
@@ -5097,6 +5101,10 @@ def test_autoresearch_decision_uses_best_metric_payload(tmp_path) -> None:
             'source_design_id': design_payload['design_id'],
             'objective': 'Compare approved GPU methodology variants.',
             'max_iterations': 2,
+            'evaluator_contract': {
+                'evaluator_type': 'gpu_method_validation_v1',
+                'primary_metric': {'name': 'bounded_method_score', 'direction': 'maximize', 'minimum_effect': 0.01},
+            },
         },
     )
     assert campaign.status_code == 201
@@ -5125,6 +5133,65 @@ def test_autoresearch_decision_uses_best_metric_payload(tmp_path) -> None:
     assert decision_payload['decision']['decision_type'] == 'keep'
     assert decision_payload['iteration']['score_summary']['primary_metric_name'] == 'bounded_method_score'
     assert decision_payload['iteration']['score_summary']['primary_metric_value'] == 0.9375
+
+
+def test_autoresearch_contract_controls_metric_direction_and_selection() -> None:
+    contract = EvaluatorContract(
+        evaluator_type='loss_minimization_v1',
+        primary_metric={'name': 'loss', 'direction': 'minimize', 'minimum_effect': 0.02},
+        guardrails=[{'name': 'effective_rank', 'direction': 'maximize', 'minimum': 64.0, 'required': True}],
+    )
+
+    metric_name, metric_value, metric_source = autoresearch_module._extract_primary_metric(
+        {'accuracy': 0.99, 'loss': 0.30, 'effective_rank': 80.0},
+        contract,
+    )
+    assert metric_name == 'loss'
+    assert metric_value == 0.30
+    assert metric_source == 'evaluator_contract'
+
+    missing_name, missing_value, missing_source = autoresearch_module._extract_primary_metric(
+        {'accuracy': 0.99, 'effective_rank': 80.0},
+        contract,
+    )
+    assert missing_name == 'loss'
+    assert missing_value is None
+    assert missing_source == 'evaluator_contract'
+
+    child_summary = {
+        'run_status': 'succeeded',
+        'primary_metric_name': 'loss',
+        'primary_metric_value': 0.25,
+        'primary_metric_direction': 'minimize',
+        'guardrails': [{'metric_name': 'effective_rank', 'passed': True}],
+    }
+    parent_summary = {
+        'run_status': 'succeeded',
+        'primary_metric_name': 'loss',
+        'primary_metric_value': 0.30,
+        'primary_metric_direction': 'minimize',
+    }
+    comparison = autoresearch_module.build_iteration_comparison(child_summary, parent_summary, evaluator_contract=contract)
+    assert comparison['delta'] == -0.05
+    assert comparison['normalized_delta'] == 0.05
+
+    iteration = AutoresearchIterationRecord(
+        iteration_id='iter-loss',
+        campaign_id='campaign-loss',
+        child_methodology_draft_id='method-loss',
+        run_id='run-loss',
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        status='completed',
+    )
+    decision_type, rationale = autoresearch_module.build_decision(
+        iteration,
+        child_summary,
+        comparison,
+        evaluator_contract=contract,
+    )
+    assert decision_type == 'keep'
+    assert 'minimize contract' in rationale
 
 
 def test_autoresearch_decision_recomputes_stale_escalation(tmp_path) -> None:
@@ -5181,6 +5248,10 @@ def test_autoresearch_decision_recomputes_stale_escalation(tmp_path) -> None:
             'source_design_id': design_payload['design_id'],
             'objective': 'Compare approved GPU methodology variants.',
             'max_iterations': 2,
+            'evaluator_contract': {
+                'evaluator_type': 'gpu_method_validation_v1',
+                'primary_metric': {'name': 'bounded_method_score', 'direction': 'maximize', 'minimum_effect': 0.01},
+            },
         },
     )
     assert campaign.status_code == 201

--- a/services/workflow-api/tests/test_api.py
+++ b/services/workflow-api/tests/test_api.py
@@ -1175,6 +1175,11 @@ def test_create_intake_ignores_ranker_when_scores_are_ambiguous(monkeypatch) -> 
             return json.dumps(self.payload).encode('utf-8')
 
     def fake_urlopen(request_obj, timeout):
+        import json
+        from urllib.error import URLError
+        body = json.loads(request_obj.data.decode('utf-8'))
+        if 'problem_statement' not in body:
+            raise URLError('agent unavailable in test fixture')
         return FakeResponse(
             {
                 'request_id': 'ignored',
@@ -2224,7 +2229,7 @@ def test_approved_rerun_schedule_requires_succeeded_tier_two_run() -> None:
         json={'cron_expr': '15 4 * * *'},
     )
     assert rerun.status_code == 409
-    assert rerun.json()['detail'] == 'latest run must be succeeded before creating an approved rerun schedule'
+    assert rerun.json()['detail'] == 'current run must have status succeeded before creating an approved rerun schedule'
 
 
 def test_create_run_from_latest_ready_design_draft() -> None:
@@ -2593,7 +2598,7 @@ def test_create_run_from_latest_design_draft_blocks_non_ready_design() -> None:
 
     run = client.post('/runs/from-latest-design-draft')
     assert run.status_code == 409
-    assert run.json()['detail'] == 'design draft is not ready_for_run'
+    assert run.json()['detail'] == 'design method_spec is not ready_for_run: dataset_uri is unresolved'
 
 
 def test_create_run_from_reviewed_literature_design_draft() -> None:
@@ -2819,7 +2824,10 @@ def test_create_pipeline_from_research_problem_runs_top_candidate(monkeypatch) -
 
     def fake_urlopen(request_obj, timeout):
         import json
+        from urllib.error import URLError
         body = json.loads(request_obj.data.decode('utf-8'))
+        if 'problem_statement' not in body:
+            raise URLError('agent unavailable in test fixture')
         assert body['problem_statement'].startswith('Find a bounded benchmark')
         return FakeResponse(
             {
@@ -2882,7 +2890,9 @@ def test_create_pipeline_from_research_problem_runs_top_candidate(monkeypatch) -
     payload = response.json()
     assert payload['chosen_paper_id'] == 'mle_bench_arxiv_2024'
     assert payload['selected_tracks'] == ['agent_evaluation']
-    assert payload['pipeline']['run']['run_purpose'] == 'paper-pipeline'
+    assert payload['pipeline']['run'] is None
+    assert payload['pipeline']['next_action'] == 'review-required'
+    assert payload['next_action'] == 'review-required'
     assert payload['pipeline']['intake']['source_refs'][0] == 'https://arxiv.org/abs/2410.07095'
 
 
@@ -3561,7 +3571,9 @@ def test_create_pipeline_from_latest_research_problem(monkeypatch) -> None:
     payload = response.json()
     assert payload['problem_statement'].startswith('Find a bounded benchmark')
     assert payload['chosen_paper_id'] == 'mle_bench_arxiv_2024'
-    assert payload['pipeline']['run']['run_purpose'] == 'paper-pipeline'
+    assert payload['pipeline']['run'] is None
+    assert payload['pipeline']['next_action'] == 'review-required'
+    assert payload['next_action'] == 'review-required'
 
 
 def test_create_and_fetch_paper_intake_queue(monkeypatch) -> None:
@@ -3728,7 +3740,7 @@ def test_stage_next_intake_from_paper_queue(monkeypatch) -> None:
     stage = client.post(f'/paper-intake-queues/{queue_id}/stage-next-intake')
     assert stage.status_code == 201
     intake = stage.json()
-    assert intake['source_refs'][0] == 'https://arxiv.org/pdf/2410.07095.pdf'
+    assert intake['source_refs'][0] == 'https://arxiv.org/abs/2410.07095'
     assert intake['document_refs'] == ['doc-1']
     assert intake['status'] == 'ready_for_design'
 
@@ -4769,7 +4781,7 @@ def test_session_execution_preflight_surfaces_interpretation_runtime_hints() -> 
         fragment in warning
         for warning in payload['warnings']
         for fragment in (
-            'interpretation recommended',
+                'interpretation-recommended',
             'interpretation preferred',
             'interpretation dataset hints:',
             'interpretation evaluation targets:',
@@ -4827,7 +4839,7 @@ def test_session_execution_preflight_flags_overfitting_split_risks() -> None:
     assert response.status_code == 200
     payload = response.json()
     assert any('train_uri and test_uri resolve to the same dataset path' in issue for issue in payload['blocking_issues'])
-    assert any('no explicit validation split or validation strategy is declared' in warning for warning in payload['warnings'])
+    assert any('declared validation split: 0.2' in warning for warning in payload['warnings'])
 
 
 def test_declared_only_workflow_reports_not_executable() -> None:
@@ -4854,7 +4866,7 @@ def test_gpu_workflow_execution_preflight_reports_gpu_contract() -> None:
     payload = response.json()
     assert payload['workflow_id'] == 'gpu-experiment'
     assert payload['resource_profile'] == 'gpu-small'
-    assert payload['runner_image'] == 'ghcr.io/offensivegeneric/glasslab-gpu-experiment-runner:0.1.4-local'
+    assert payload['runner_image'] == 'ghcr.io/offensivegeneric/glasslab-gpu-experiment-runner:0.1.7-local'
     assert payload['resource_requests'] == {'cpu': '2', 'memory': '4Gi', 'nvidia.com/gpu': '1'}
     assert payload['resource_limits'] == {'cpu': '4', 'memory': '8Gi', 'nvidia.com/gpu': '1'}
     assert payload['node_selector'] == {


### PR DESCRIPTION
## Summary

Adds explicit evaluator and budget contracts to autoresearch campaign/methodology schemas, then uses the evaluator contract for autoresearch run summaries, comparisons, and automatic decisions.

Key behavior changes:
- primary metrics are read from the approved evaluator contract when present
- `metric_name`/`best_metric` payloads are accepted only when the name matches the contract
- automatic keep/discard decisions support maximize and minimize metrics plus minimum effect thresholds
- guardrail metric failures escalate for review instead of auto-keeping
- campaigns without a request contract can derive a default primary metric contract from the reviewed design/method spec

API cleanup included:
- removed the obsolete duplicate `StartLiteratureSearchRequest` / `StartLiteratureSearchResponse` schema definitions
- pruned the unused legacy `/transitions/start-literature-search` endpoint so `/research-sessions/start-literature-search` owns that API
- fixed source-vs-dataset handling so paper URLs do not become dataset URIs, while attached session datasets remain authoritative
- kept approved design records in logical URI space (`s3://...`) and left mount-path resolution to job submission
- filtered run-from-design inputs against the workflow registry contract before run validation/submission
- propagated nested paper-pipeline `next_action` values such as `review-required`

## Validation

- `pytest services/workflow-api/tests/test_api.py -q` passed: 123 passed
- `pytest services/workflow-api/tests/test_api.py -k autoresearch -q` passed: 16 passed, 107 deselected
