### PR TITLE
Publish research workspace runner from main

### DIFF
--- a/.github/workflows/research-workspace-runner-image.yml
+++ b/.github/workflows/research-workspace-runner-image.yml
@@ -1,0 +1,97 @@
+name: Release Research Workspace Runner
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/research-workspace-runner/**"
+      - "services/workflow-registry/definitions/research-workspace-cpu-v1.json"
+      - ".github/workflows/research-workspace-runner-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: release-research-workspace-runner
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve registry-pinned image
+        id: image
+        shell: bash
+        run: |
+          python <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          from pathlib import Path
+
+          definition = json.loads(
+              Path(
+                  "services/workflow-registry/definitions/"
+                  "research-workspace-cpu-v1.json"
+              ).read_text()
+          )
+          image_ref = definition["runner_image"]
+          image, separator, tag = image_ref.rpartition(":")
+          expected = (
+              "ghcr.io/"
+              + "${{ github.repository_owner }}".lower()
+              + "/glasslab-research-workspace-runner"
+          )
+          if not separator or not tag:
+              raise SystemExit("runner_image must contain an explicit tag")
+          if image != expected:
+              raise SystemExit(
+                  f"runner_image repository mismatch: {image!r} != {expected!r}"
+              )
+          print(f"image={image}")
+          print(f"tag={tag}")
+          print(f"image_ref={image_ref}")
+          print(f"sha_ref={image}:sha-${{ github.sha }}")
+          PY
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/research-workspace-runner/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.image.outputs.image_ref }}
+            ${{ steps.image.outputs.sha_ref }}
+          build-args: |
+            GLASSLAB_GIT_SHA=${{ github.sha }}
+            GLASSLAB_BUILD_SOURCE=github:${{ github.run_id }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+
+      - name: Record published image
+        run: |
+          {
+            echo "### Research workspace runner"
+            echo
+            echo "- Version: \`${{ steps.image.outputs.tag }}\`"
+            echo "- Image: \`${{ steps.image.outputs.image_ref }}\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- Source: \`${{ github.sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- publish the registry-pinned `research-workspace-cpu-v1` image automatically when its runner, registry definition, or release workflow changes on `main`
- publish both the semantic registry tag and a source-commit tag
- attach BuildKit provenance and an SBOM
- keep `workflow_dispatch` for operator rebuilds

## Why

PR #78 made the investigation-native CPU workspace executable in source, but the registry image must exist before `.44` can roll it out. The installed GitHub integration cannot dispatch the existing manual image workflow, and this Work Mode environment has no network route to the authoritative provisioner. A main-branch release workflow makes the image supply chain reproducible and removes that manual publication gap.

## Validation

- workflow YAML parses
- repository config/docs checks pass
- resolved tree is exactly the locally validated one-file change

After merge, this workflow should publish `ghcr.io/offensivegeneric/glasslab-research-workspace-runner:0.1.0`; live manifests still must be applied from `.44`.