### PR TITLE
Add a required pull request gate

### DIFF
--- a/.github/workflows/ci-configs.yml
+++ b/.github/workflows/ci-configs.yml
@@ -1,16 +1,7 @@
 name: CI Configs
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - ".github/workflows/**"
-      - "kubeadm/**/*.yml"
-      - "kubeadm/**/*.yaml"
-      - "**/*.json"
-      - "**/*.yml"
-      - "**/*.yaml"
-      - "scripts/validate-configs.py"
+  workflow_call:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,15 +1,7 @@
 name: CI Docs
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - "README.md"
-      - "CONTRIBUTING.md"
-      - "docs/**/*.md"
-      - "scripts/check-doc-links.py"
-      - "scripts/check-before-push.sh"
-      - ".github/workflows/ci-docs.yml"
+  workflow_call:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,12 +1,7 @@
 name: CI Python
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - "services/**/*.py"
-      - "services/**/requirements*.txt"
-      - ".github/workflows/ci-python.yml"
+  workflow_call:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -1,12 +1,7 @@
 name: CI Scripts
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - "scripts/**/*.sh"
-      - "scripts/*.sh"
-      - ".github/workflows/ci-scripts.yml"
+  workflow_call:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,64 @@
+name: PR Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  configs:
+    uses: ./.github/workflows/ci-configs.yml
+
+  docs:
+    uses: ./.github/workflows/ci-docs.yml
+
+  scripts:
+    uses: ./.github/workflows/ci-scripts.yml
+
+  python:
+    uses: ./.github/workflows/ci-python.yml
+
+  required:
+    name: Glasslab PR Gate
+    if: ${{ always() }}
+    needs:
+      - configs
+      - docs
+      - scripts
+      - python
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every CI lane to pass
+        env:
+          CONFIGS_RESULT: ${{ needs.configs.result }}
+          DOCS_RESULT: ${{ needs.docs.result }}
+          SCRIPTS_RESULT: ${{ needs.scripts.result }}
+          PYTHON_RESULT: ${{ needs.python.result }}
+        run: |
+          failed=0
+          for result in \
+            "$CONFIGS_RESULT" \
+            "$DOCS_RESULT" \
+            "$SCRIPTS_RESULT" \
+            "$PYTHON_RESULT"; do
+            if [[ "$result" != "success" ]]; then
+              failed=1
+            fi
+          done
+
+          if [[ "$failed" -ne 0 ]]; then
+            printf 'Required lane results: configs=%s docs=%s scripts=%s python=%s\n' \
+              "$CONFIGS_RESULT" \
+              "$DOCS_RESULT" \
+              "$SCRIPTS_RESULT" \
+              "$PYTHON_RESULT" >&2
+            exit 1
+          fi
+
+          echo "All required Glasslab PR lanes passed."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,28 @@ The default check mirrors the default CI signal:
 - Python syntax for services
 - workflow-api core tests
 
+## Pull Request Flow
+
+Create one branch for one coherent change and open a pull request into `main`.
+Continue pushing revisions to the same branch; GitHub updates the pull request
+automatically.
+
+`main` is protected. A merge requires:
+
+- the always-running `Glasslab PR Gate` check
+- one approval from someone other than the author
+- all review conversations resolved
+- a current approval after material revisions
+
+Use squash merge, then delete the feature branch. Direct administrator pushes
+are an incident-recovery bypass, not a normal development path.
+
 ## CI Lanes
 
-Default GitHub checks are intentionally small and path-aware.
+Every pull request runs the four reusable CI lanes below. Their results are
+combined into the required `Glasslab PR Gate` check. Path-aware copies still
+run after relevant changes land on `main`, and compatibility tests remain
+manual.
 
 | Lane | Purpose |
 | --- | --- |


### PR DESCRIPTION
## Summary

- add one always-running `Glasslab PR Gate` for pull requests into `main`
- reuse the existing config, docs, scripts, and Python CI workflows
- remove duplicate path-filtered PR triggers while preserving path-aware post-merge checks
- document the protected-branch contribution flow

## Validation

- `python3 scripts/validate-configs.py`
- `python3 scripts/check-doc-links.py`
- `bash -n scripts/check-before-push.sh`
- `git diff --check`

## Rollout

After this PR's gate passes and the PR is merged, configure GitHub `main` protection to require:

- `Glasslab PR Gate`
- one approving review
- resolved review conversations
- fresh approval after new commits
- no force pushes or deletion

Repository administrators retain an emergency bypass.