### PR TITLE
Stage contributor password retirement

### DIFF
--- a/ansible/group_vars/identity_hosts.yml
+++ b/ansible/group_vars/identity_hosts.yml
@@ -10,6 +10,7 @@ glasslab_identity_users:
   - username: gr66ss-glasslab
     display_name: Glasslab infrastructure administrator
     state: present
+    password_locked: true
     targets: [gateway, provisioner, exo]
     darwin_uid: 502
     roles:
@@ -23,6 +24,9 @@ glasslab_identity_users:
   - username: denic
     display_name: Denise Cakoni
     state: present
+    # Keep the existing password during key onboarding. Set true only after a
+    # successful key-only login has been confirmed from every active client.
+    password_locked: false
     targets: [gateway, provisioner, exo]
     darwin_uid: 503
     roles:
@@ -35,6 +39,9 @@ glasslab_identity_users:
   - username: tristanc
     display_name: Tristan C
     state: present
+    # Keep the existing password during key onboarding. Set true only after a
+    # successful key-only login has been confirmed from every active client.
+    password_locked: false
     targets: [gateway, provisioner, exo]
     darwin_uid: 504
     roles:

--- a/ansible/playbooks/manage-lab-identities.yml
+++ b/ansible/playbooks/manage-lab-identities.yml
@@ -21,6 +21,7 @@
       ansible.builtin.assert:
         that:
           - item.state in ['present', 'disabled']
+          - item.password_locked is boolean
           - item.targets | difference(['gateway', 'provisioner', 'exo']) | length == 0
           - item.roles | difference(['lab_contributor', 'exo_contributor', 'container_builder', 'infrastructure_admin']) | length == 0
           - item.state == 'disabled' or item.authorized_keys | length > 0

--- a/ansible/playbooks/tasks/manage-linux-identities.yml
+++ b/ansible/playbooks/tasks/manage-linux-identities.yml
@@ -22,7 +22,7 @@
          (['sudo'] if 'infrastructure_admin' in item.roles else [])) | join(',')
       }}
     append: false
-    password_lock: true
+    password_lock: "{{ item.password_locked }}"
     state: present
   loop: "{{ glasslab_active_identity_users }}"
   loop_control:
@@ -128,11 +128,11 @@
 - name: Flush SSH configuration changes before finishing the host
   ansible.builtin.meta: flush_handlers
 
-- name: Verify active Linux accounts are key-only
+- name: Verify requested Linux password locks
   ansible.builtin.command: "passwd -S {{ item.username }}"
   register: glasslab_linux_password_status
   changed_when: false
-  failed_when: "' L ' not in glasslab_linux_password_status.stdout"
+  failed_when: "item.password_locked and ' L ' not in glasslab_linux_password_status.stdout"
   loop: "{{ glasslab_active_identity_users }}"
   loop_control:
     label: "{{ item.username }}"

--- a/docs/contributor-access.md
+++ b/docs/contributor-access.md
@@ -50,6 +50,11 @@ Host glasslab-exo18
 Public keys should be installed on both hosts. Password reuse between the
 gateway and provisioner is not the account synchronization mechanism.
 
+Password retirement is staged. Existing passwords remain available until the
+contributor has demonstrated key-only login from every computer they actively
+use. An administrator then changes the account's committed
+`password_locked` setting and reapplies the identity playbook.
+
 ## Development Checkouts
 
 Contributors must develop in separate clones under their own home directories.

--- a/docs/identity-management.md
+++ b/docs/identity-management.md
@@ -69,9 +69,10 @@ cd /home/glasslab/cluster-config
 ```
 
 The play runs one host at a time. It sets the exact approved SSH keys and role
-groups, locks Linux passwords, validates sudoers and sshd configuration, and
-keeps exo shared files group-writable. A second `check` run should report no
-changes except where a platform tool cannot report idempotence.
+groups, enforces each account's staged password-lock setting, validates sudoers
+and sshd configuration, and keeps exo shared files group-writable. A second
+`check` run should report no changes except where a platform tool cannot report
+idempotence.
 
 ## Add Or Change A Contributor
 
@@ -80,10 +81,22 @@ changes except where a platform tool cannot report idempotence.
    `glasslab_identity_managed_usernames`.
 3. Assign only required targets and roles.
 4. Run the check command, review the diff, then apply.
-5. Have the contributor verify each intended SSH alias and run `id`.
+5. Initially set `password_locked: false` when adopting an account that
+   already uses password authentication.
+6. Have the contributor verify each intended SSH alias and run `id`.
+7. Have the contributor force a key-only test from every active client:
+
+   ```bash
+   ssh -o PreferredAuthentications=publickey \
+     -o PasswordAuthentication=no <alias>
+   ```
+
+8. After those tests are recorded, change `password_locked` to `true` in a
+   separate reviewed change and apply again.
 
 Do not accept a private key, add a shared password, or put a GitHub token in
-Ansible variables.
+Ansible variables. Installing a public key is not sufficient evidence that the
+contributor's current SSH client possesses and offers the matching private key.
 
 ## Revoke Access
 


### PR DESCRIPTION
## Incident

The first authoritative identity rollout locked Deni's and Tristan's existing Linux passwords before key-only login had been verified from every client. Their approved public keys were installed, but their home clients fell back to password authentication.

The previous password hashes have been unlocked live on the gateway and provisioner. No password was reset or disclosed.

## Change

- make password locking explicit per identity
- keep Deni and Tristan in transitional password-enabled state
- retain key-only state for the infrastructure administrator
- document key-only verification before password retirement
- keep revocation behavior unchanged

## Validation

- YAML/JSON parsing passed
- Markdown link checking passed
- Ansible syntax check passed on the provisioner
- live check mode passed against gateway and provisioner
- gateway/provisioner account states report `P` for Deni and Tristan

## Follow-up

After each contributor proves public-key login from every active client, change that user's `password_locked` value to `true` in a separate reviewed PR.