### PR TITLE
Provision scoped Kubernetes contributor access

### DIFF
--- a/ansible/group_vars/identity_hosts.yml
+++ b/ansible/group_vars/identity_hosts.yml
@@ -33,6 +33,7 @@ glasslab_identity_users:
       - lab_contributor
       - exo_contributor
       - container_builder
+      - kubernetes_observer
     authorized_keys:
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPf4zU2Goac9RK6Yvz+dx14Jfg4wYP46GCs1NG2ba3KA denick@Mac
 
@@ -48,9 +49,17 @@ glasslab_identity_users:
       - lab_contributor
       - exo_contributor
       - container_builder
+      - kubernetes_observer
     authorized_keys:
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBDiZFcFbKimUVq5WOjd13e4ElYUsBSvVSbg7tVwA0gp tristanc@glasslab
 
 glasslab_exo_shared_group: glasslab-exo
 glasslab_exo_shared_paths:
   - /Users/glasslab/exo-clean
+
+glasslab_kubernetes_admin_kubeconfig: /home/glasslab/.kube/config
+glasslab_kubernetes_observer_namespaces:
+  - glasslab-v2
+  - glasslab-agents
+glasslab_kubernetes_client_certificate_seconds: 31536000
+glasslab_kubernetes_client_renew_before_seconds: 2592000

--- a/ansible/playbooks/manage-lab-identities.yml
+++ b/ansible/playbooks/manage-lab-identities.yml
@@ -23,7 +23,7 @@
           - item.state in ['present', 'disabled']
           - item.password_locked is boolean
           - item.targets | difference(['gateway', 'provisioner', 'exo']) | length == 0
-          - item.roles | difference(['lab_contributor', 'exo_contributor', 'container_builder', 'infrastructure_admin']) | length == 0
+          - item.roles | difference(['lab_contributor', 'exo_contributor', 'container_builder', 'kubernetes_observer', 'infrastructure_admin']) | length == 0
           - item.state == 'disabled' or item.authorized_keys | length > 0
           - "'exo' not in item.targets or item.darwin_uid is defined"
         fail_msg: "Identity record for {{ item.username }} is invalid."
@@ -57,6 +57,12 @@
     - name: Apply macOS identity policy
       ansible.builtin.include_tasks: tasks/manage-darwin-identities.yml
       when: ansible_system == 'Darwin'
+
+    - name: Apply provisioner Kubernetes observer policy
+      ansible.builtin.include_tasks: tasks/manage-kubernetes-observers.yml
+      when:
+        - ansible_system == 'Linux'
+        - identity_scope == 'provisioner'
 
     - name: Reject unsupported identity hosts
       ansible.builtin.fail:

--- a/ansible/playbooks/tasks/manage-kubernetes-observers.yml
+++ b/ansible/playbooks/tasks/manage-kubernetes-observers.yml
@@ -1,0 +1,151 @@
+---
+- name: Build the active Kubernetes observer list
+  ansible.builtin.set_fact:
+    glasslab_kubernetes_observer_users: >-
+      {{ glasslab_active_identity_users |
+         selectattr('roles', 'contains', 'kubernetes_observer') | list }}
+
+- name: Verify the Kubernetes administrator kubeconfig exists
+  ansible.builtin.stat:
+    path: "{{ glasslab_kubernetes_admin_kubeconfig }}"
+  register: glasslab_kubernetes_admin_kubeconfig_stat
+
+- name: Require the Kubernetes administrator kubeconfig
+  ansible.builtin.assert:
+    that:
+      - glasslab_kubernetes_admin_kubeconfig_stat.stat.exists
+      - glasslab_kubernetes_admin_kubeconfig_stat.stat.isreg
+    fail_msg: >-
+      The provisioner cannot manage contributor Kubernetes access without
+      {{ glasslab_kubernetes_admin_kubeconfig }}.
+
+- name: Render contributor observer RBAC
+  ansible.builtin.template:
+    src: "{{ playbook_dir }}/../templates/kubernetes-observer-rbac.yml.j2"
+    dest: /etc/glasslab-kubernetes-observer-rbac.yml
+    owner: root
+    group: root
+    mode: '0600'
+  register: glasslab_kubernetes_observer_rbac
+
+- name: Apply contributor observer RBAC
+  ansible.builtin.command:
+    argv:
+      - kubectl
+      - --kubeconfig
+      - "{{ glasslab_kubernetes_admin_kubeconfig }}"
+      - apply
+      - -f
+      - /etc/glasslab-kubernetes-observer-rbac.yml
+  register: glasslab_kubernetes_observer_rbac_apply
+  changed_when: >-
+    ' created' in glasslab_kubernetes_observer_rbac_apply.stdout or
+    ' configured' in glasslab_kubernetes_observer_rbac_apply.stdout
+  when: not ansible_check_mode
+
+- name: Provision personal Kubernetes observer kubeconfigs
+  ansible.builtin.command:
+    argv:
+      - "{{ playbook_dir }}/../../scripts/provision-kubernetes-observer.sh"
+      - "{{ item.username }}"
+      - "{{ glasslab_kubernetes_admin_kubeconfig }}"
+      - "{{ glasslab_kubernetes_client_certificate_seconds | string }}"
+      - "{{ glasslab_kubernetes_client_renew_before_seconds | string }}"
+      - "{{ glasslab_kubernetes_observer_namespaces | join(',') }}"
+  register: glasslab_kubernetes_observer_provision
+  changed_when: "'changed=true' in glasslab_kubernetes_observer_provision.stdout"
+  loop: "{{ glasslab_kubernetes_observer_users }}"
+  loop_control:
+    label: "{{ item.username }}"
+  when: not ansible_check_mode
+
+- name: Find managed Kubernetes credentials no longer assigned
+  ansible.builtin.stat:
+    path: "/home/{{ item }}/.kube/.glasslab-managed-observer"
+  loop: "{{ glasslab_identity_managed_usernames }}"
+  register: glasslab_managed_kubernetes_markers
+  loop_control:
+    label: "{{ item }}"
+
+- name: Remove revoked managed Kubernetes observer credentials
+  ansible.builtin.file:
+    path: "/home/{{ item.item }}/.kube"
+    state: absent
+  when:
+    - item.stat.exists
+    - item.item not in (glasslab_kubernetes_observer_users | map(attribute='username') | list)
+  loop: "{{ glasslab_managed_kubernetes_markers.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+
+- name: Verify observers can read workload status
+  ansible.builtin.command:
+    argv:
+      - runuser
+      - -u
+      - "{{ item.0.username }}"
+      - --
+      - kubectl
+      - --kubeconfig
+      - "/home/{{ item.0.username }}/.kube/config"
+      - auth
+      - can-i
+      - get
+      - pods
+      - --namespace
+      - "{{ item.1 }}"
+  register: glasslab_kubernetes_observer_read_check
+  changed_when: false
+  failed_when: glasslab_kubernetes_observer_read_check.stdout | trim != 'yes'
+  loop: "{{ glasslab_kubernetes_observer_users | product(glasslab_kubernetes_observer_namespaces) | list }}"
+  loop_control:
+    label: "{{ item.0.username }} in {{ item.1 }}"
+  when: not ansible_check_mode
+
+- name: Verify observers cannot submit jobs
+  ansible.builtin.command:
+    argv:
+      - runuser
+      - -u
+      - "{{ item.0.username }}"
+      - --
+      - kubectl
+      - --kubeconfig
+      - "/home/{{ item.0.username }}/.kube/config"
+      - auth
+      - can-i
+      - create
+      - jobs.batch
+      - --namespace
+      - "{{ item.1 }}"
+  register: glasslab_kubernetes_observer_submit_check
+  changed_when: false
+  failed_when: glasslab_kubernetes_observer_submit_check.stdout | trim != 'no'
+  loop: "{{ glasslab_kubernetes_observer_users | product(glasslab_kubernetes_observer_namespaces) | list }}"
+  loop_control:
+    label: "{{ item.0.username }} in {{ item.1 }}"
+  when: not ansible_check_mode
+
+- name: Verify observers cannot read secrets
+  ansible.builtin.command:
+    argv:
+      - runuser
+      - -u
+      - "{{ item.0.username }}"
+      - --
+      - kubectl
+      - --kubeconfig
+      - "/home/{{ item.0.username }}/.kube/config"
+      - auth
+      - can-i
+      - get
+      - secrets
+      - --namespace
+      - "{{ item.1 }}"
+  register: glasslab_kubernetes_observer_secret_check
+  changed_when: false
+  failed_when: glasslab_kubernetes_observer_secret_check.stdout | trim != 'no'
+  loop: "{{ glasslab_kubernetes_observer_users | product(glasslab_kubernetes_observer_namespaces) | list }}"
+  loop_control:
+    label: "{{ item.0.username }} in {{ item.1 }}"
+  when: not ansible_check_mode

--- a/ansible/templates/kubernetes-observer-rbac.yml.j2
+++ b/ansible/templates/kubernetes-observer-rbac.yml.j2
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: glasslab-contributor-observer
+  labels:
+    app.kubernetes.io/managed-by: glasslab-identity-ansible
+rules:
+  - apiGroups: [""]
+    resources:
+      - events
+      - pods
+      - pods/log
+      - pods/status
+      - persistentvolumeclaims
+      - services
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+    verbs: ["get", "list", "watch"]
+{% for namespace in glasslab_kubernetes_observer_namespaces %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: glasslab-contributor-observers
+  namespace: {{ namespace }}
+  labels:
+    app.kubernetes.io/managed-by: glasslab-identity-ansible
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: glasslab-contributor-observer
+subjects:
+{% for user in glasslab_kubernetes_observer_users %}
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: {{ user.username }}
+{% endfor %}
+{% endfor %}

--- a/docs/identity-management.md
+++ b/docs/identity-management.md
@@ -11,7 +11,7 @@ personal SSH key
        v
 public gateway (glasslab.org)
        |
-       +--> provisioner (.44): Git, Ansible, kubectl, optional Docker
+       +--> provisioner (.44): Git, scoped kubectl, optional Docker
        |
        +--> exo17 / exo18: personal shell, shared exo worktree
 
@@ -46,10 +46,40 @@ continues through the provisioner's `clusteradmin` automation identity.
 | `lab_contributor` | Personal gateway login and provisioner `glasslab` group |
 | `exo_contributor` | Personal exo login and `glasslab-exo` shared-worktree group |
 | `container_builder` | Provisioner `docker` group; this is root-equivalent |
+| `kubernetes_observer` | Personal `.44` kubeconfig with read-only workload access in approved namespaces |
 | `infrastructure_admin` | `sudo` plus an audited passwordless sudoers entry |
 
 Roles only take effect where they make sense. For example,
 `container_builder` does not add a group on the gateway or Macs.
+
+## Kubernetes Contributor Access
+
+The `kubernetes_observer` role creates a personal client certificate and
+`~/.kube/config` on the provisioner. It grants `get`, `list`, and `watch` for
+pods, logs, events, jobs, workload controllers, services, and persistent volume
+claims in `glasslab-v2` and `glasslab-agents`.
+
+It does not grant access to secrets, pod exec or attach, job creation, node
+resources, RBAC, or cluster mutation. Contributors submit GPU work through the
+research orchestrator, which validates and records the requested job. Direct
+worker SSH remains an infrastructure-admin recovery path rather than an
+experiment interface.
+
+From the provisioner, an observer can use:
+
+```bash
+kubectl get jobs
+kubectl get pods
+kubectl logs <pod>
+kubectl config use-context glasslab-agents
+kubectl auth can-i --list
+```
+
+The certificates are issued through the Kubernetes CSR API for one year and
+renewed by the identity playbook when fewer than 30 days remain. RBAC binds the
+certificate's username directly, so disabling or removing the role from a
+ledger entry removes that user from the namespace bindings. The playbook also
+removes credentials that it previously managed for a revoked observer.
 
 The legacy shared `glasslab` account is not in the personal-account ledger. It
 is retained as a service owner and break-glass path while remaining software is
@@ -70,9 +100,9 @@ cd /home/glasslab/cluster-config
 
 The play runs one host at a time. It sets the exact approved SSH keys and role
 groups, enforces each account's staged password-lock setting, validates sudoers
-and sshd configuration, and keeps exo shared files group-writable. A second
-`check` run should report no changes except where a platform tool cannot report
-idempotence.
+and sshd configuration, manages provisioner Kubernetes observer credentials,
+and keeps exo shared files group-writable. A second `check` run should report no
+changes except where a platform tool cannot report idempotence.
 
 ## Add Or Change A Contributor
 
@@ -106,9 +136,10 @@ removes supplementary role groups, and removes `authorized_keys`. On macOS it
 changes the shell to `/usr/bin/false`, removes supplementary role groups, and
 removes `authorized_keys`. Home directories and audit evidence are preserved.
 
-After revocation, separately remove repository access in GitHub and terminate
-any active Kubernetes credentials. Unix, GitHub, and Kubernetes remain
-intentional separate trust boundaries.
+After revocation, separately remove repository access in GitHub. The identity
+playbook removes managed kubeconfigs and the user from Kubernetes RoleBindings;
+already issued certificates then authenticate as a user with no permissions.
+Unix, GitHub, and Kubernetes remain intentional separate trust boundaries.
 
 ## Recovery
 

--- a/scripts/provision-kubernetes-observer.sh
+++ b/scripts/provision-kubernetes-observer.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <username> <admin-kubeconfig> <certificate-seconds> <renew-before-seconds> <namespaces>" >&2
+}
+
+if [[ $# -ne 5 ]]; then
+  usage
+  exit 2
+fi
+
+username="$1"
+admin_kubeconfig="$2"
+certificate_seconds="$3"
+renew_before_seconds="$4"
+namespace_csv="$5"
+
+if [[ ! "$username" =~ ^[a-z_][a-z0-9_-]*$ ]] ||
+   [[ ! "$certificate_seconds" =~ ^[0-9]+$ ]] ||
+   [[ ! "$renew_before_seconds" =~ ^[0-9]+$ ]] ||
+   [[ ! "$namespace_csv" =~ ^[a-z0-9.-]+(,[a-z0-9.-]+)*$ ]]; then
+  usage
+  exit 2
+fi
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "This script must run as root." >&2
+  exit 1
+fi
+
+if [[ ! -f "$admin_kubeconfig" ]]; then
+  echo "Administrator kubeconfig not found: $admin_kubeconfig" >&2
+  exit 1
+fi
+
+if ! id "$username" >/dev/null 2>&1; then
+  echo "Unix account not found: $username" >&2
+  exit 1
+fi
+
+home_dir="$(getent passwd "$username" | cut -d: -f6)"
+user_group="$(id -gn "$username")"
+kube_dir="$home_dir/.kube"
+key_path="$kube_dir/client.key"
+cert_path="$kube_dir/client.crt"
+ca_path="$kube_dir/ca.crt"
+config_path="$kube_dir/config"
+marker_path="$kube_dir/.glasslab-managed-observer"
+csr_name="glasslab-user-${username}"
+changed=false
+
+install -d -m 0700 -o "$username" -g "$user_group" "$kube_dir"
+
+certificate_is_current=false
+if [[ -s "$key_path" && -s "$cert_path" ]] &&
+   openssl x509 -checkend "$renew_before_seconds" -noout -in "$cert_path" >/dev/null 2>&1; then
+  certificate_is_current=true
+fi
+
+if [[ "$certificate_is_current" != true ]]; then
+  private_key_tmp="$(mktemp)"
+  csr_tmp="$(mktemp)"
+  certificate_tmp="$(mktemp)"
+  trap 'rm -f "$private_key_tmp" "$csr_tmp" "$certificate_tmp"' EXIT
+
+  openssl genpkey -algorithm ED25519 -out "$private_key_tmp"
+  openssl req -new \
+    -key "$private_key_tmp" \
+    -subj "/CN=${username}/O=glasslab-contributors" \
+    -out "$csr_tmp"
+
+  kubectl --kubeconfig "$admin_kubeconfig" delete \
+    certificatesigningrequest "$csr_name" --ignore-not-found >/dev/null
+
+  encoded_request="$(base64 -w0 < "$csr_tmp")"
+  kubectl --kubeconfig "$admin_kubeconfig" apply -f - >/dev/null <<EOF
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: ${csr_name}
+spec:
+  request: ${encoded_request}
+  signerName: kubernetes.io/kube-apiserver-client
+  expirationSeconds: ${certificate_seconds}
+  usages:
+    - client auth
+EOF
+
+  kubectl --kubeconfig "$admin_kubeconfig" certificate approve "$csr_name" >/dev/null
+
+  for _ in $(seq 1 30); do
+    encoded_certificate="$(kubectl --kubeconfig "$admin_kubeconfig" get \
+      certificatesigningrequest "$csr_name" \
+      -o jsonpath='{.status.certificate}')"
+    if [[ -n "$encoded_certificate" ]]; then
+      printf '%s' "$encoded_certificate" | base64 -d > "$certificate_tmp"
+      break
+    fi
+    sleep 1
+  done
+
+  if [[ ! -s "$certificate_tmp" ]]; then
+    echo "Certificate was not issued for $username." >&2
+    exit 1
+  fi
+
+  install -m 0600 -o "$username" -g "$user_group" "$private_key_tmp" "$key_path"
+  install -m 0644 -o "$username" -g "$user_group" "$certificate_tmp" "$cert_path"
+  changed=true
+fi
+
+server="$(kubectl --kubeconfig "$admin_kubeconfig" config view --raw --minify \
+  -o jsonpath='{.clusters[0].cluster.server}')"
+kubectl --kubeconfig "$admin_kubeconfig" config view --raw --flatten --minify \
+  -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' |
+  base64 -d > "$ca_path"
+
+config_tmp="$(mktemp)"
+trap 'rm -f "${private_key_tmp:-}" "${csr_tmp:-}" "${certificate_tmp:-}" "$config_tmp"' EXIT
+
+kubectl --kubeconfig "$config_tmp" config set-cluster glasslab \
+  --server="$server" \
+  --certificate-authority="$ca_path" \
+  --embed-certs=true >/dev/null
+kubectl --kubeconfig "$config_tmp" config set-credentials "$username" \
+  --client-certificate="$cert_path" \
+  --client-key="$key_path" \
+  --embed-certs=true >/dev/null
+
+IFS=',' read -r -a namespaces <<< "$namespace_csv"
+for namespace in "${namespaces[@]}"; do
+  kubectl --kubeconfig "$config_tmp" config set-context "$namespace" \
+    --cluster=glasslab \
+    --user="$username" \
+    --namespace="$namespace" >/dev/null
+done
+kubectl --kubeconfig "$config_tmp" config use-context "${namespaces[0]}" >/dev/null
+
+if [[ ! -f "$config_path" ]] || ! cmp -s "$config_tmp" "$config_path"; then
+  install -m 0600 -o "$username" -g "$user_group" "$config_tmp" "$config_path"
+  changed=true
+fi
+install -m 0644 -o "$username" -g "$user_group" /dev/null "$marker_path"
+chown "$username:$user_group" "$ca_path"
+chmod 0644 "$ca_path"
+
+echo "changed=$changed"


### PR DESCRIPTION
## Summary
- add an Ansible-managed `kubernetes_observer` role for Deni and Tristan
- issue personal one-year client certificates and provisioner-local kubeconfigs
- grant read-only workload/log visibility in `glasslab-v2` and `glasslab-agents`
- verify observers cannot submit jobs or read secrets
- document orchestrator submission versus worker SSH and kubectl inspection

## Validation
- `bash -n scripts/provision-kubernetes-observer.sh`
- `python3 scripts/validate-configs.py`
- provisioner Ansible syntax/check and live RBAC verification to follow
