### PR TITLE
Resolve workflow artifact PVC paths

### DIFF
--- a/services/research-orchestrator/app/artifact_delivery.py
+++ b/services/research-orchestrator/app/artifact_delivery.py
@@ -38,6 +38,10 @@ class VerifiedArtifactReader:
             candidates.append(self.root / relative)
         elif not uri.startswith(('s3://', 'job://', 'contract://')):
             candidates.append(Path(uri) if uri.startswith('/') else self.root / uri)
+            # workflow-api artifact references historically include the
+            # logical bucket name even though the mounted PVC is that bucket.
+            if uri.startswith('artifacts/'):
+                candidates.append(self.root / uri.removeprefix('artifacts/'))
 
         for candidate in candidates:
             resolved = candidate.resolve()
@@ -187,4 +191,3 @@ def build_run_artifact_bundle(
         content=payload,
         artifact_count=len(delivered),
     )
-

--- a/services/research-orchestrator/tests/test_artifact_delivery.py
+++ b/services/research-orchestrator/tests/test_artifact_delivery.py
@@ -117,6 +117,22 @@ def test_bundle_contains_successful_verified_results_and_manifest(tmp_path) -> N
     assert manifest['artifacts'][0]['sha256'] == artifacts[0].sha256
 
 
+def test_reader_resolves_workflow_api_artifacts_bucket_prefix(tmp_path) -> None:
+    content = b'{"score": 0.75}\n'
+    path = tmp_path / 'external-run-1' / 'metrics.json'
+    path.parent.mkdir()
+    path.write_bytes(content)
+    artifact = ArtifactRecord(
+        run_id='run-1',
+        job_id='job-1',
+        type='metrics.json',
+        uri='artifacts/external-run-1/metrics.json',
+        sha256=sha256(content).hexdigest(),
+    )
+
+    assert VerifiedArtifactReader(str(tmp_path)).resolve(artifact) == path
+
+
 def test_analysis_notebook_embeds_verified_metrics_and_tables(tmp_path) -> None:
     metrics = _artifact(
         tmp_path,


### PR DESCRIPTION
## Summary
- resolve the exact historical `artifacts/` logical-bucket prefix against the artifact PVC root
- retain root confinement and digest verification
- cover the live workflow-api URI shape with a regression test

## Validation
- research-orchestrator: 94 passed
- live validation identified and reproduced the path mismatch
