### PR TITLE
Accept common metrics output patterns

### DIFF
--- a/services/research-orchestrator/app/preflight.py
+++ b/services/research-orchestrator/app/preflight.py
@@ -110,6 +110,24 @@ def _dict_keys(
     return keys
 
 
+def _references_metrics_json(
+    expression: ast.expr,
+    assignments: dict[str, ast.expr],
+    *,
+    resolving: frozenset[str] = frozenset(),
+) -> bool:
+    if isinstance(expression, ast.Name):
+        if expression.id in resolving:
+            return False
+        assigned = assignments.get(expression.id)
+        return assigned is not None and _references_metrics_json(
+            assigned,
+            assignments,
+            resolving=resolving | {expression.id},
+        )
+    return 'metrics.json' in ast.unparse(expression)
+
+
 def _metrics_root_errors(
     tree: ast.AST,
     *,
@@ -135,6 +153,12 @@ def _metrics_root_errors(
                 subscript_keys.setdefault(target.value.id, set()).add(
                     target.slice.value
                 )
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.value is not None
+        ):
+            assignments[node.target.id] = node.value
         if not isinstance(node, ast.With):
             continue
         for item in node.items:
@@ -144,8 +168,10 @@ def _metrics_root_errors(
                 or not item.context_expr.args
             ):
                 continue
-            target_text = ast.unparse(item.context_expr.args[0])
-            if 'metrics.json' in target_text:
+            if _references_metrics_json(
+                item.context_expr.args[0],
+                assignments,
+            ):
                 metric_handles.add(item.optional_vars.id)
 
     serialized_keys: set[str] = set()

--- a/services/research-orchestrator/tests/test_contract_policy_matrix.py
+++ b/services/research-orchestrator/tests/test_contract_policy_matrix.py
@@ -324,6 +324,58 @@ def test_adult_preflight_rejects_nested_only_metrics_json(
     )
 
 
+def test_adult_preflight_accepts_assigned_path_and_annotated_metrics(
+    orchestrator_bundle,
+) -> None:
+    _, _, _, _, engine = orchestrator_bundle
+    run = engine.create_run(
+        request=RunCreateRequest(objective='Accept common typed output patterns.')
+    )
+    workspace = Path(run.beaker_workspace)
+    config = workspace / 'configs' / 'candidate.yaml'
+    config.write_text(
+        'experiment_dimensions:\n'
+        '  model: [logistic_regression, random_forest]\n'
+        '  missing_strategy: [impute_unknown]\n'
+        '  include_fnlwgt: [false]\n'
+        '  encoding: [one_hot]\n'
+    )
+    source = workspace / 'benchmark-workspace' / 'adult-income'
+    source.mkdir(parents=True)
+    (source / 'run.py').write_text(
+        'import json\n'
+        'from pathlib import Path\n'
+        'metrics: dict[str, object] = {\n'
+        '    "accuracy": 0.9, "balanced_accuracy": 0.8,\n'
+        '    "precision": 0.8, "recall": 0.8, "f1": 0.8,\n'
+        '    "roc_auc": 0.9, "headline_ci_low": 0.85,\n'
+        '    "headline_ci_high": 0.95, "bootstrap_resamples": 1000,\n'
+        '    "test_rows": 16281,\n'
+        '}\n'
+        'metrics_path = Path("output") / "metrics.json"\n'
+        'with open(metrics_path, "w") as handle:\n'
+        '    json.dump(metrics, handle)\n'
+    )
+    report = preflight_matrix(
+        run=run.model_copy(
+            update={
+                'task_definition': {
+                    'source_subdirectory': 'benchmark-workspace/adult-income',
+                }
+            }
+        ),
+        matrix=_matrix().model_copy(
+            update={'base_config': 'configs/candidate.yaml'}
+        ),
+        contract=engine.contracts.resolve(
+            'ml-benchmark-adult-income-v1',
+            '1.1.0',
+        ),
+    )
+
+    assert report.passed
+
+
 def test_adult_preflight_rejects_metadata_wrapped_methodology_values(
     orchestrator_bundle,
 ) -> None:


### PR DESCRIPTION
## Summary
- resolve simple assigned paths when locating metrics.json writes
- recognize annotated metrics dictionaries during root-key validation
- add regression coverage for the pattern generated by Beaker

## Validation
- `PYTHONPATH=. pytest -q tests/test_contract_policy_matrix.py` (10 passed)
- `PYTHONPATH=. pytest -q` (95 passed)
- `git diff --check`