### PR TITLE
Reset revision budget after execution

### DIFF
--- a/services/research-orchestrator/app/engine.py
+++ b/services/research-orchestrator/app/engine.py
@@ -3205,6 +3205,14 @@ class ResearchOrchestrator:
             input_event=evidence,
         )
         if not result.done:
+            self.store.reset_methodology_revision_budget(
+                run_id,
+                reason=(
+                    'new cluster evidence requires a post-execution repair '
+                    'cycle'
+                ),
+            )
+            self._publish_latest(run_id)
             self._transition(run_id, RunState.BEAKER_REVISING)
             self._beaker_revise(
                 run_id,

--- a/services/research-orchestrator/app/storage.py
+++ b/services/research-orchestrator/app/storage.py
@@ -312,6 +312,62 @@ class SqliteStore:
                 )
         return updated
 
+    def reset_methodology_revision_budget(
+        self,
+        run_id: str,
+        *,
+        reason: str,
+    ) -> RunRecord:
+        with self.transaction() as connection:
+            row = connection.execute(
+                'SELECT payload, version FROM runs WHERE run_id = ?',
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                raise RecordNotFound(run_id)
+            current = RunRecord.model_validate_json(row['payload'])
+            now = utc_now()
+            updated = current.model_copy(
+                update={
+                    'methodology_revision_count': 0,
+                    'version': int(row['version']) + 1,
+                    'updated_at': now,
+                }
+            )
+            cursor = connection.execute(
+                '''
+                UPDATE runs
+                SET state = ?, version = ?, payload = ?, updated_at = ?
+                WHERE run_id = ? AND version = ?
+                ''',
+                (
+                    updated.state.value,
+                    updated.version,
+                    _dump(updated),
+                    updated.updated_at.isoformat(),
+                    run_id,
+                    int(row['version']),
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise ConcurrencyConflict(
+                    f'run was updated concurrently: {run_id}'
+                )
+            self._append_event_conn(
+                connection,
+                run_id=run_id,
+                source='orchestrator',
+                event_type='methodology.revision_budget_reset',
+                payload={
+                    'previous_revision_count': (
+                        current.methodology_revision_count
+                    ),
+                    'revision_count': 0,
+                    'reason': reason,
+                },
+            )
+        return updated
+
     def transition_run(
         self,
         run_id: str,

--- a/services/research-orchestrator/tests/test_workflow.py
+++ b/services/research-orchestrator/tests/test_workflow.py
@@ -72,6 +72,57 @@ def test_human_approval_states_stop_active_runtime_clock(
     assert revising.active_runtime_seconds == waiting.active_runtime_seconds
 
 
+def test_failed_result_starts_a_fresh_methodology_revision_budget(
+    orchestrator_bundle,
+    monkeypatch,
+) -> None:
+    _, store, _, _, engine = orchestrator_bundle
+    run = engine.create_run(
+        RunCreateRequest(objective='Repair a failed executed experiment.')
+    )
+    verifying = store.replace_run(
+        run.model_copy(
+            update={
+                'state': RunState.HONEYDEW_VERIFYING,
+                'methodology_revision_count': 2,
+            }
+        ),
+        expected_version=run.version,
+    )
+    monkeypatch.setattr(
+        engine,
+        '_run_agent_turn',
+        lambda **_kwargs: (
+            None,
+            AgentTurnResult(
+                kind=TurnKind.VERIFICATION,
+                summary='The executed candidate needs a code repair.',
+                done=False,
+            ),
+        ),
+    )
+    monkeypatch.setattr(engine, '_beaker_revise', lambda *_args, **_kwargs: None)
+
+    engine._verify_results(verifying.run_id)
+
+    revising = store.get_run(verifying.run_id)
+    assert revising.state == RunState.BEAKER_REVISING
+    assert revising.methodology_revision_count == 0
+    reset = next(
+        event
+        for event in store.list_events(verifying.run_id)
+        if event.event_type == 'methodology.revision_budget_reset'
+    )
+    assert reset.payload['previous_revision_count'] == 2
+    assert reset.payload['revision_count'] == 0
+
+    engine._request_methodology_revision(
+        verifying.run_id,
+        feedback='The first post-execution repair remains incomplete.',
+    )
+    assert store.get_run(verifying.run_id).methodology_revision_count == 1
+
+
 def test_evidence_snapshot_projects_bounded_verified_artifact_contents(
     orchestrator_bundle,
 ) -> None:


### PR DESCRIPTION
## Summary
- start a fresh methodology revision budget when new cluster evidence requires repair
- persist the counter reset and audit event in one transaction
- verify the first post-execution rejection starts at revision 1

## Validation
- focused revision-budget test: 1 passed
- full research-orchestrator suite: 96 passed
- `git diff --check`