### PR TITLE
Add contributor agent handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,268 @@
+# Glasslab Agent Handoff
+
+This file is the first stop for coding agents working with Glasslab. Read it
+before inferring architecture from older documents or changing live systems.
+
+## Authority And Vocabulary
+
+There are three different kinds of truth:
+
+1. **Committed state** is the GitHub repository.
+2. **Documented live state** is the last checked snapshot in the docs.
+3. **Actual live state** must be queried from the provisioner and cluster.
+
+Do not describe documented state as current without checking it live.
+
+Use these names consistently:
+
+- **Glasslab**: the overall lab and project, not a host.
+- **gateway**: public SSH entry host `glasslab.org`, hostname `glasslab`.
+- **provisioner**: PXE, Ansible, canonical repo, and `kubectl` host at
+  `192.168.1.44`, hostname `glasslab-PXE-01`.
+- **control plane**: Kubernetes host `cp01` at `192.168.1.49`.
+- **workers**: Kubernetes `node01` through `node05`.
+- **shared `glasslab` account**: a legacy Unix administrator identity, not a
+  machine name. Prefer personal accounts.
+
+Normal access is:
+
+```text
+contributor workstation
+  -> gateway
+  -> provisioner
+  -> Kubernetes API or Ansible-managed nodes
+```
+
+Use `ssh glasslab-gateway` and `ssh glasslab-provisioner` when those aliases
+are installed. The canonical live checkout is:
+
+```text
+/home/glasslab/cluster-config
+```
+
+A laptop checkout is a client copy. Never use it alone to make a claim about
+live pods, secrets, ignored files, imported images, or runtime data.
+
+## Current Product
+
+The current human-facing research path is:
+
+```text
+Discord
+  -> research-orchestrator
+  -> isolated Honeydew and Beaker OpenCode runtimes
+  -> structured, policy-checked action requests
+  -> workflow-api
+  -> bounded Kubernetes Jobs
+  -> immutable evaluator and artifact records
+  -> Discord status, approvals, and report delivery
+```
+
+The responsibilities are deliberately separate:
+
+- **Honeydew** drafts `program.md`, reviews methodology and implementation,
+  verifies evidence, and writes `report.md`.
+- **Beaker** writes the implementation and candidate configuration, runs
+  bounded local checks, proposes experiment matrices, and analyzes job results.
+- **research-orchestrator** owns state transitions, approvals, agent sessions,
+  policy, recovery, job watching, and the append-only event log.
+- **workflow-api** is the bounded cluster execution control plane.
+- **evaluation contracts** are immutable to both agents and decide whether job
+  evidence satisfies the approved contract.
+- **Discord** is an interface and transcript projection, not authoritative
+  memory or state.
+
+Both agents currently use separate OpenCode processes and sessions against the
+exo OpenAI-compatible endpoint configured for the shared Qwen model. Their
+workspaces and OpenCode data are isolated per run and agent.
+
+Primary code and deployment areas:
+
+- `services/research-orchestrator/`
+- `services/research-workspace-runner/`
+- `services/workflow-api/`
+- `kubeadm/glasslab-v2/research-orchestrator/`
+- `docs/research-orchestrator.md`
+- `docs/research-orchestrator-command-surface.md`
+
+The following are not the current research front door:
+
+- `services/agent-api`, `services/runner`, and `kubeadm/agent-stack` are the
+  legacy Titanic v1 reference implementation.
+- OpenClaw and WhatsApp material is compatibility or historical context unless
+  a current task explicitly targets those adapters.
+- The older `!new`, `!plan`, and related command vocabulary does not describe
+  the active Honeydew/Beaker Discord slash-command surface.
+
+## Discord Workflow
+
+Start an attached research task in the configured Glasslab channel:
+
+```text
+/task-start archive:<zip> objective:<optional narrower objective>
+```
+
+Start a question-driven run without a task archive:
+
+```text
+/research-start objective:<research objective>
+```
+
+Upload local data before starting a task:
+
+```text
+/dataset-upload dataset:<file> name:<stable-name> role:<role> contains_labels:<bool>
+```
+
+Put the returned `glasslab-dataset://<sha256>` reference in `problem.md` or the
+research objective. Do not embed large datasets in the task ZIP.
+
+The expected lifecycle is:
+
+1. Honeydew drafts the protocol and evaluation-contract proposal.
+2. A human approves or rejects the protocol in Discord.
+3. Beaker plans and implements the bounded workload.
+4. Deterministic preflight and Honeydew review the implementation and matrix.
+5. A human approves or rejects cluster execution.
+6. The orchestrator submits bounded jobs and records authoritative status.
+7. Beaker analyzes results; Honeydew independently verifies them.
+8. Honeydew writes the report; a human accepts or rejects it.
+
+Use these controls inside a run thread:
+
+```text
+/research-pause
+/research-resume
+/research-cancel
+/research-artifacts
+```
+
+Approve and Reject are Discord buttons, not slash commands. A failed job is
+normally evidence for Beaker to analyze and revise; it is not automatically a
+failed research run. `FAILED`, `CANCELLED`, and `TIMED_OUT` are terminal states
+and cannot currently be resumed through `/research-resume`.
+
+Read `docs/research-orchestrator-command-surface.md` before operating a run.
+
+## Scientific And Execution Boundaries
+
+- Agent prose is not evidence that an action occurred.
+- Only durable job, event, artifact, and evaluator records are authoritative.
+- Neither agent receives raw `kubectl`, SSH, cluster credentials, secrets,
+  image publication, Git push, or unrestricted job submission.
+- A model proposes normalized actions. Deterministic code renders and submits
+  the final job.
+- The workload emits metrics and evidence. It must not create or score
+  `evaluation.json`, `integrity_pass`, or `rubric_score`.
+- Every contract-required workload artifact must be produced. Preflight checks
+  source references before cluster submission; the evaluator verifies actual
+  files afterward.
+- Matrix seeds create separate cluster jobs. If one job already performs an
+  internal multi-seed stability analysis, use one outer matrix seed instead of
+  duplicating the internal seed list.
+- Do not claim scientific confirmation from one exploratory run. Promote
+  promising results into a frozen, multi-seed confirmatory campaign.
+
+## Inspecting A Live Run
+
+First check the service and cluster from the provisioner:
+
+```bash
+ssh glasslab-provisioner
+sudo -n env KUBECONFIG=/home/glasslab/.kube/config \
+  kubectl -n glasslab-v2 get pod,job -o wide
+```
+
+The orchestrator is internal-only. Port-forward it from a contributor
+workstation:
+
+```bash
+ssh -L 18080:127.0.0.1:18080 glasslab-provisioner \
+  'sudo -n env KUBECONFIG=/home/glasslab/.kube/config \
+   kubectl -n glasslab-v2 port-forward \
+   svc/glasslab-research-orchestrator 18080:8080'
+```
+
+Then inspect authoritative read APIs:
+
+```bash
+curl -fsS http://127.0.0.1:18080/runs | jq
+curl -fsS http://127.0.0.1:18080/runs/<run-id>/events | jq
+curl -fsS http://127.0.0.1:18080/runs/<run-id>/artifacts | jq
+```
+
+Per-run durable files are mounted in the orchestrator pod at:
+
+```text
+/mnt/artifacts/research-orchestrator/runs/<run-id>/
+  protocol/
+  beaker-worktree/
+  honeydew-worktree/
+  reports/
+  events/
+  runtime/beaker/
+  runtime/honeydew/
+```
+
+The shared PVC is backed by NFS. Inspect workspaces through the pod rather than
+assuming that path exists on the provisioner's local filesystem.
+
+## Development And Delivery
+
+Work on one branch per coherent change and open a pull request into protected
+`main`. Direct administrator pushes are for incident recovery only.
+
+Before pushing:
+
+```bash
+./scripts/check-before-push.sh
+```
+
+Useful narrower checks:
+
+```bash
+./scripts/check-before-push.sh --docs
+./scripts/check-before-push.sh --configs
+./scripts/check-before-push.sh --python-core
+```
+
+GitHub Actions publishes service images under the full commit SHA. After a
+merged service change, deploy the exact release from the canonical provisioner
+checkout:
+
+```bash
+cd /home/glasslab/cluster-config
+./scripts/rollout-research-services.sh --sync
+```
+
+Do not build a second deployment path or manually mutate tracked manifests to
+work around this release flow.
+
+## Security And Collaboration Rules
+
+- Never commit passwords, private keys, API tokens, Discord credentials,
+  webhook URLs, kubeconfigs, or live secret manifests.
+- Do not copy secrets into prompts, issues, pull requests, screenshots, or
+  shell history.
+- Use personal accounts and the provisioner-managed access policy.
+- Contributors submit research through the orchestrator; they do not normally
+  SSH to workers or receive unrestricted cluster-admin credentials.
+- Preserve unrelated local changes on the provisioner. Inspect `git status`
+  before syncing or deploying.
+- Prefer current docs and code over historical snapshots. When documents
+  conflict, identify the conflict instead of silently choosing the convenient
+  version.
+
+## Reading Order
+
+1. `README.md`
+2. `docs/research-orchestrator-command-surface.md`
+3. `docs/research-orchestrator.md`
+4. `docs/access-topology.md`
+5. `docs/contributor-access.md`
+6. `CONTRIBUTING.md`
+7. `docs/glasslab-v2/current/README.md`
+
+For infrastructure work, additionally read the relevant Ansible playbooks and
+`docs/glasslab-v2/runbooks/`. For legacy behavior, read historical documents
+only after understanding the current path above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ secondary, compatibility-only, or historical.
 
 Read these first:
 
+- `AGENTS.md`
 - `README.md`
 - `docs/access-topology.md`
 - `docs/contributor-access.md`

--- a/README.md
+++ b/README.md
@@ -56,31 +56,22 @@ The current Discord and operator commands, arbitrary-task intake limits, and
 live progress are summarized in
 [`docs/research-orchestrator-command-surface.md`](docs/research-orchestrator-command-surface.md).
 
-The active product is `glasslab-v2`.
+The active product is the `glasslab-v2` research orchestrator.
 
-The canonical local command path is:
+The canonical human research path is:
 
-- `OpenCode`
-- exo OpenAI-compatible serving
-- repo-owned scripts
+- Discord
+- `research-orchestrator`
+- isolated Honeydew and Beaker OpenCode runtimes
+- exo OpenAI-compatible model serving
 - `workflow-api`
+- bounded Kubernetes Jobs
 
-The optional remote adapter path is:
-
-- `whatsapp-gateway`
-- `research-ingress`
-- `research-command-router`
-- `workflow-api`
-
-The canonical control plane is:
-
-- `workflow-api`
-
-The canonical bounded inference lane is:
-
-- exo OpenAI-compatible serving
-
-There is no supported OpenClaw path in the current product.
+OpenCode is the agents' inner tool-use runtime, not the durable workflow or
+human approval surface. `workflow-api` remains the canonical cluster execution
+control plane. WhatsApp, OpenClaw, and the older command-router path are
+compatibility or historical material rather than the current research front
+door.
 
 ## Primary Operator Loop
 
@@ -96,14 +87,15 @@ question
   -> claim and next experiment
 ```
 
-OpenCode is the primary interactive surface. WhatsApp commands and
-research-session routes remain compatibility adapters; they are not the
-investigation data model.
+Discord is the primary human surface. The research orchestrator's database and
+append-only event log are authoritative; Discord is their operator-facing
+projection. OpenCode remains internal to Honeydew and Beaker.
 
 ## Start Here
 
 If you want the current source of truth:
 
+- [AGENTS.md](AGENTS.md) for the concise coding-agent and contributor handoff
 - [CONTRIBUTING.md](CONTRIBUTING.md)
 - [docs/glasslab-v2/current/README.md](docs/glasslab-v2/current/README.md)
 - [docs/glasslab-v2/canonical-stack-2026-04.md](docs/glasslab-v2/canonical-stack-2026-04.md)

--- a/docs/operator-orientation.md
+++ b/docs/operator-orientation.md
@@ -1,5 +1,11 @@
 # Operator Orientation
 
+> **Historical orientation:** this document predates the deployed
+> Honeydew/Beaker research orchestrator and still describes OpenClaw as the
+> operator layer. For current agent and operator context, start with
+> [`../AGENTS.md`](../AGENTS.md) and
+> [`research-orchestrator-command-surface.md`](research-orchestrator-command-surface.md).
+
 This document is for one purpose: to let you remember what Glasslab is without reloading the whole repo into your head.
 
 It is not a deployment runbook. It is the map.

--- a/docs/research-orchestrator-command-surface.md
+++ b/docs/research-orchestrator-command-surface.md
@@ -1,6 +1,6 @@
 # Research Orchestrator Command Surface
 
-Last verified: 2026-07-29
+Last verified: 2026-08-06
 
 This is the concise operator and contributor reference for the Honeydew/Beaker
 research workflow. The database and append-only event log are authoritative.
@@ -27,6 +27,61 @@ and do not require an ID.
 
 Discord does not currently expose list or status slash commands. Status is
 shown by the run thread's editable status message.
+
+## Intended End-To-End Run
+
+For a task ZIP, begin in the main configured Glasslab channel:
+
+```text
+/task-start archive:<attach ZIP> objective:<optional narrower objective>
+```
+
+The bot creates one public thread for the run. Continue from that thread:
+
+1. Honeydew drafts `program.md` and a logical evaluation-contract proposal.
+2. Read the protocol approval brief and use its Approve or Reject button.
+3. Beaker writes `implementation-plan.md`, the workload, candidate config, and
+   a normalized experiment matrix.
+4. Deterministic preflight runs before Honeydew reviews the implementation.
+   Rejected proposals return to Beaker with concrete feedback.
+5. Read the execution approval brief. It must state job count, variants,
+   seeds, resources, required artifacts, contract, and authorization scope.
+6. Approve to submit the bounded matrix through `workflow-api`. Agent turns are
+   idle while Kubernetes jobs run.
+7. Beaker analyzes authoritative job and artifact records. Honeydew verifies
+   the important claims against evaluator output and the approved protocol.
+8. Honeydew writes `report.md`; use the final acceptance control to complete
+   the run.
+9. Use `/research-artifacts` to download the verified result bundle.
+
+Approve and Reject are message buttons, not slash commands. An approval only
+authorizes the described action; it is not evidence that execution succeeded.
+
+For a question without an archive, use `/research-start`. Honeydew still begins
+with the protocol and evaluation contract. For local data, run
+`/dataset-upload` first and put the returned `glasslab-dataset://<sha256>`
+reference in `problem.md` or the objective.
+
+## Failure And Recovery Behavior
+
+- A deterministic preflight failure rejects the matrix before cluster work and
+  sends the exact errors back to Beaker.
+- A Kubernetes job failure is recorded as experimental evidence and normally
+  sends the workflow to Beaker analysis, followed by Honeydew verification.
+- If verification finds missing or invalid evidence, a fresh bounded revision
+  budget begins and Beaker receives the failure details.
+- `/research-pause` aborts an active model turn but preserves the worktree and
+  recovery checkpoint. `/research-resume` starts a fresh OpenCode session from
+  that checkpoint.
+- `FAILED`, `CANCELLED`, and `TIMED_OUT` are terminal. They cannot currently be
+  resumed. Retry-from-terminal-checkpoint is a known missing capability.
+- The run thread must receive a persisted follow-up for an execution or
+  interaction failure; an ephemeral Discord error is not sufficient.
+
+The workload emits metrics and evidence; the immutable evaluator owns
+`evaluation.json`, `integrity_pass`, and `rubric_score`. Matrix seeds create
+independent jobs. Do not copy an internal stability-seed list into the outer
+matrix when one job already executes that list.
 
 ## Result Artifacts
 
@@ -197,6 +252,36 @@ POST /actions/{action_id}/reject
 Do not put the operator token, Discord token, or webhook URL in documentation,
 Git, shell history, or screenshots.
 
+## Inspecting A Run
+
+Discord is the readable transcript, but the database, event log, job records,
+and artifact registry are authoritative. The service is `ClusterIP` only. From
+a contributor workstation, create a tunnel through the provisioner:
+
+```bash
+ssh -L 18080:127.0.0.1:18080 glasslab-provisioner \
+  'sudo -n env KUBECONFIG=/home/glasslab/.kube/config \
+   kubectl -n glasslab-v2 port-forward \
+   svc/glasslab-research-orchestrator 18080:8080'
+```
+
+In another terminal:
+
+```bash
+RUN=<run-id>
+curl -fsS "http://127.0.0.1:18080/runs/$RUN" | jq
+curl -fsS "http://127.0.0.1:18080/runs/$RUN/events" | jq
+curl -fsS "http://127.0.0.1:18080/runs/$RUN/artifacts" | jq
+curl -N "http://127.0.0.1:18080/runs/$RUN/events/stream"
+```
+
+The run's workspaces, protocol, reports, OpenCode data, and recovery checkpoints
+are stored beneath
+`/mnt/artifacts/research-orchestrator/runs/<run-id>/` in the orchestrator pod.
+Use `kubectl exec` from the provisioner to inspect them. The HTTP API does not
+yet expose a dedicated full-turn endpoint; normalized events are the stable
+external record, while raw OpenCode storage is an implementation detail.
+
 ## Deployment Commands
 
 GitHub Actions publishes a matched pair of immutable images under the full
@@ -246,7 +331,7 @@ Implemented and live:
 
 Validated:
 
-- 67 research-orchestrator tests
+- 98 research-orchestrator tests
 - 159 workflow-api tests
 - mocked complete research workflow
 - live OpenCode/Qwen structured task compilation
@@ -260,15 +345,18 @@ Validated:
 
 Benchmark milestone:
 
-- Adult Income run `406b2d800d3b4e9a90af79e6b1b0ab55` was created from
-  the pre-registered compatibility task.
-- Honeydew drafted its protocol and the protocol was approved.
-- The first Beaker implementation turn wrote experiment code but timed out
-  before returning its structured matrix proposal.
-- Pause/resume recovery started Beaker turn 3; no experiment Kubernetes Job
-  had been submitted at the time of this update.
-- This records a workflow milestone, not benchmark completion.
-- Wine and Fashion-MNIST are preflight-ready but have not completed live runs.
+- Adult Income run `cce710ceef97441685c777c8f19c767b` completed the
+  orchestrator workflow and final acceptance path.
+- Wine run `39101d9c9d3d4753bcd74e93e6106819` submitted cluster jobs. The
+  workload calculations completed, but the immutable evaluator rejected the
+  first results because `plots/clusters.png` was missing.
+- Honeydew identified the missing evidence and Beaker added the plot. Beaker's
+  final one-job replacement matrix passed deterministic preflight, but the
+  overall research run reached `TIMED_OUT` before Honeydew review and execution
+  approval.
+- This validates failure evidence, revision-budget reset, artifact preflight,
+  and one-job seed handling. It does not constitute a completed Wine result.
+- Fashion-MNIST is preflight-ready but has not completed a live run.
 
 The Adult, Wine, and Fashion-MNIST definitions are compatibility fixtures with
 pre-registered datasets and task-specific evaluators. The generic extension
@@ -281,6 +369,8 @@ path is `/task-start`, not another hardcoded task entry.
 - fixed approved repository and runtime profiles
 - no authenticated remote dataset download or private object-store browser
 - no Discord list or status commands
+- no first-class HTTP endpoint for complete structured turn inspection
+- no retry or clone operation from a terminal run checkpoint
 - no automatic Git push or pull request creation
 - no arbitrary SSH, `kubectl`, secret access, or container publication for
   either agent


### PR DESCRIPTION
## Summary

- add root `AGENTS.md` with stable architecture, access, Discord, execution, and contributor rules
- add `HANDOFF.md` as a compact current implementation and live-operations checkpoint for switching agents
- make GitHub Issues the authoritative backlog, with `TODO.md` as a short priority index
- add a structured Glasslab work-item issue form and issue-maintenance guidance
- expand the research-orchestrator command guide and align current/historical documentation

## Backlog reset

- created current issues #92-#102 with priority, state, area, scope, and acceptance criteria
- closed obsolete issues #60-#76 with explanatory supersession comments while preserving their history
- added `priority:p0`, `priority:p1`, `priority:p2`, and `area:research-orchestrator` labels

## Why

Contributors and their coding agents were reconstructing current context from overlapping historical documents and chat history. Stable rules, current handoff state, and actionable work now have separate homes. GitHub Issues provide assignment, discussion, dependencies, and closure history without requiring `TODO.md` to duplicate status.

## Validation

- `./scripts/check-before-push.sh --docs`
- `git diff --check`

Refs #102