### PR TITLE
Add current handoff and issue-backed work queue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Glasslab contributor guide
+    url: https://github.com/OffensiveGeneric/glasslab-cluster-config/blob/main/CONTRIBUTING.md
+    about: Read the architecture, access, issue, branch, test, and pull-request workflow.

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -1,0 +1,68 @@
+name: Glasslab work item
+description: Propose a bounded implementation, validation, infrastructure, or documentation task
+title: ""
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        GitHub Issues are the Glasslab work queue. Keep one issue focused on one independently reviewable outcome.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is missing, broken, unclear, or unnecessarily manual?
+      placeholder: Describe the observed problem and who it affects.
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Intended outcome
+      description: State the observable result, not only an implementation idea.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and constraints
+      description: Identify affected services, trust boundaries, live-cluster needs, and explicit exclusions.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Add a checkable list that another contributor can verify.
+      placeholder: |
+        - [ ] Behavior is implemented
+        - [ ] Automated tests cover the change
+        - [ ] Documentation reflects the new behavior
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence and references
+      description: Link related runs, events, artifacts, logs, issues, PRs, or documentation. Do not paste secrets.
+    validations:
+      required: false
+  - type: dropdown
+    id: live_validation
+    attributes:
+      label: Live cluster validation
+      options:
+        - Not required
+        - Required from the provisioner
+        - Unknown; determine during implementation
+    validations:
+      required: true
+  - type: checkboxes
+    id: hygiene
+    attributes:
+      label: Submission checks
+      options:
+        - label: I checked for an existing issue covering the same outcome.
+          required: true
+        - label: This issue contains no credentials, tokens, or private dataset contents.
+          required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This file is the first stop for coding agents working with Glasslab. Read it
 before inferring architecture from older documents or changing live systems.
+It contains stable operating rules. Read `HANDOFF.md` for summarized current
+state and `TODO.md` for links into the authoritative GitHub Issues work queue.
 
 ## Authority And Vocabulary
 
@@ -255,13 +257,15 @@ work around this release flow.
 
 ## Reading Order
 
-1. `README.md`
-2. `docs/research-orchestrator-command-surface.md`
-3. `docs/research-orchestrator.md`
-4. `docs/access-topology.md`
-5. `docs/contributor-access.md`
-6. `CONTRIBUTING.md`
-7. `docs/glasslab-v2/current/README.md`
+1. `HANDOFF.md`
+2. `TODO.md`
+3. `README.md`
+4. `docs/research-orchestrator-command-surface.md`
+5. `docs/research-orchestrator.md`
+6. `docs/access-topology.md`
+7. `docs/contributor-access.md`
+8. `CONTRIBUTING.md`
+9. `docs/glasslab-v2/current/README.md`
 
 For infrastructure work, additionally read the relevant Ansible playbooks and
 `docs/glasslab-v2/runbooks/`. For legacy behavior, read historical documents

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ secondary, compatibility-only, or historical.
 Read these first:
 
 - `AGENTS.md`
+- `HANDOFF.md`
+- `TODO.md`
 - `README.md`
 - `docs/access-topology.md`
 - `docs/contributor-access.md`
@@ -51,6 +53,19 @@ The default check mirrors the default CI signal:
 Create one branch for one coherent change and open a pull request into `main`.
 Continue pushing revisions to the same branch; GitHub updates the pull request
 automatically.
+
+Start substantive work from a GitHub issue. The issue is the authoritative
+record for scope, status, acceptance criteria, dependencies, and discussion;
+`TODO.md` is only a short priority index. Before coding:
+
+1. Check for an existing issue.
+2. Create one with the work-item template if none exists.
+3. Apply one `priority:*`, one `state:*`, and the relevant `area:*` labels.
+4. Comment when taking ownership and link the working branch or pull request.
+
+Use `Closes #<issue>` in the pull request when the merge fully resolves the
+work. If it only contributes to a larger issue, use `Refs #<issue>` and leave
+the remaining acceptance criteria visible on the issue.
 
 `main` is protected. A merge requires:
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -64,10 +64,10 @@ includes:
 
 The orchestrator test suite passed 98 tests for that release. GitHub CI passed.
 
-Documentation work is in PR #91 on branch
-`docs/contributor-agent-handoff`. It adds `AGENTS.md`, this handoff, `TODO.md`,
-and updates the current Discord/operator documentation. Do not treat it as
-merged until GitHub confirms it is on `main`.
+PR #91 merged the root `AGENTS.md` and current Discord/operator documentation.
+This summarized handoff and the issue-backed work queue are follow-up changes
+on branch `docs/contributor-agent-handoff`; do not treat them as merged until
+their follow-up pull request is on `main`.
 
 GitHub Issues are again the authoritative work queue. The active backlog was
 reset on 2026-08-06: obsolete OpenClaw, WhatsApp, literature, and old

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,175 @@
+# Glasslab Current Handoff
+
+Last updated: 2026-08-06
+
+This is the compact current-state checkpoint for switching human or coding
+agents. Read `AGENTS.md` first for stable rules and architecture. Read
+`TODO.md` for the prioritized work queue.
+
+## Current Direction
+
+The active research path is:
+
+```text
+Discord
+  -> research-orchestrator
+  -> Honeydew and Beaker agent runtimes
+  -> workflow-api
+  -> bounded Kubernetes Jobs
+  -> immutable evaluation and artifacts
+```
+
+Honeydew owns protocol, methodology review, evidence verification, and the
+final report. Beaker owns implementation, experiment proposals, and result
+analysis. The orchestrator, not either model, owns state transitions,
+approvals, policy, job submission, and durable records.
+
+OpenCode currently supplies the inner agent loop. Hermes Agent is being
+considered as a replacement for the custom OpenCode runtime/API integration
+and possibly the Discord transport. It is not approved as a replacement for
+the Glasslab state machine, evaluation contracts, artifact provenance, or
+`workflow-api`.
+
+## Authority And Access
+
+- GitHub is committed state.
+- The provisioner at `192.168.1.44` is the canonical live checkout and cluster
+  operations host.
+- Actual live state must be checked from the provisioner; laptop state and docs
+  alone are insufficient.
+- Canonical checkout on the provisioner:
+  `/home/glasslab/cluster-config`.
+- Normal access aliases are `glasslab-gateway` and `glasslab-provisioner`.
+- Cluster workers are not normal contributor login targets.
+
+The research orchestrator is a single pod on `node05`. Its state and per-run
+workspaces are on `glasslab-shared-artifacts`, backed by NFS at
+`192.168.1.207:/volume1/backup/glasslab-v2/shared-artifacts`.
+
+Both agent runtimes are configured to use the exo OpenAI-compatible service at
+`192.168.1.17:52415`. The cabled exo pair is `.17` and `.18`.
+
+## Latest Implemented Changes
+
+The deployed research-orchestrator image corresponds to commit `624de3d` and
+includes:
+
+- a fresh methodology revision budget after new cluster evidence requires
+  repair
+- deterministic preflight rejection when workload source does not reference a
+  contract-required artifact
+- rejection of duplicated internal and outer multi-seed axes
+- prompt guidance distinguishing internal stability trials from independent
+  cluster repetitions
+
+The orchestrator test suite passed 98 tests for that release. GitHub CI passed.
+
+Documentation work is in PR #91 on branch
+`docs/contributor-agent-handoff`. It adds `AGENTS.md`, this handoff, `TODO.md`,
+and updates the current Discord/operator documentation. Do not treat it as
+merged until GitHub confirms it is on `main`.
+
+GitHub Issues are again the authoritative work queue. The active backlog was
+reset on 2026-08-06: obsolete OpenClaw, WhatsApp, literature, and old
+autoresearch issues were closed with their history preserved. Current work is
+indexed in `TODO.md` and tracked in issues #92 through #102.
+
+## Current Research Runs
+
+### Adult Income
+
+Run `cce710ceef97441685c777c8f19c767b` reached `COMPLETE`, including final
+acceptance. It is the current completed end-to-end compatibility example.
+
+### Wine Clustering
+
+Run `39101d9c9d3d4753bcd74e93e6106819` is `TIMED_OUT` at turn 20.
+
+What happened:
+
+1. The initial matrix incorrectly expanded ten internal stability seeds into
+   ten outer cluster jobs.
+2. Workload calculations completed, but the evaluator rejected the results
+   because `plots/clusters.png` was absent.
+3. Honeydew identified the missing evidence.
+4. Beaker added a deterministic PCA cluster plot using Matplotlib's
+   noninteractive backend.
+5. Beaker proposed a corrected matrix with one outer job and seed `17`.
+6. Live deterministic preflight passed with no errors.
+7. The overall run deadline expired before Honeydew could review the final
+   proposal and expose execution approval.
+
+No corrected Wine job was submitted. The implementation and final proposal
+remain preserved in the timed-out run workspace. Terminal runs cannot currently
+be resumed through `/research-resume`.
+
+### Fashion-MNIST
+
+The compatibility task is preflight-ready but has not completed a live run.
+
+## Immediate Continuation
+
+Do not restart Wine from protocol drafting. First implement a controlled retry
+or clone-from-terminal-checkpoint operation that:
+
+- creates a new durable run and runtime budget
+- copies only approved protocol, task binding, worktree checkpoint, and latest
+  valid pending proposal
+- records lineage to the terminal parent run
+- invalidates stale pending actions
+- resumes at deterministic preflight and Honeydew methodology review
+- never silently submits a job or bypasses human approval
+
+Then use that path to continue the preserved one-job Wine proposal through
+Honeydew review, Discord execution approval, one corrected cluster job,
+evaluation, report, and final acceptance.
+
+## Inspect Live State
+
+From a contributor workstation:
+
+```bash
+ssh glasslab-provisioner
+sudo -n env KUBECONFIG=/home/glasslab/.kube/config \
+  kubectl -n glasslab-v2 get pods,jobs -o wide
+```
+
+For the internal orchestrator API, create a tunnel:
+
+```bash
+ssh -L 18080:127.0.0.1:18080 glasslab-provisioner \
+  'sudo -n env KUBECONFIG=/home/glasslab/.kube/config \
+   kubectl -n glasslab-v2 port-forward \
+   svc/glasslab-research-orchestrator 18080:8080'
+```
+
+Then:
+
+```bash
+RUN=39101d9c9d3d4753bcd74e93e6106819
+curl -fsS "http://127.0.0.1:18080/runs/$RUN" | jq
+curl -fsS "http://127.0.0.1:18080/runs/$RUN/events" | jq
+curl -fsS "http://127.0.0.1:18080/runs/$RUN/artifacts" | jq
+```
+
+Per-run files are available inside the orchestrator pod at:
+
+```text
+/mnt/artifacts/research-orchestrator/runs/<run-id>/
+```
+
+## Known Risks
+
+- One orchestrator replica and SQLite WAL remain a scaling limitation.
+- Agent turns can be slow against the shared exo model; large evidence bundles
+  amplify the problem.
+- Terminal checkpoint retry is missing.
+- Complete structured turns do not have a first-class read-only HTTP endpoint.
+- OpenCode runtime caches consume substantial shared storage per run.
+- Discord has no explicit list or status slash command; the editable thread
+  message is the normal status surface.
+- A generic arbitrary-dataset run has not yet completed end to end.
+
+Update this file whenever the active deployment, current blocker, or next legal
+workflow step materially changes. Keep historical detail in dated docs or run
+records rather than allowing this handoff to grow indefinitely.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ projection. OpenCode remains internal to Honeydew and Beaker.
 If you want the current source of truth:
 
 - [AGENTS.md](AGENTS.md) for the concise coding-agent and contributor handoff
+- [HANDOFF.md](HANDOFF.md) for the summarized current implementation checkpoint
+- [TODO.md](TODO.md) for the prioritized index into the GitHub Issues work queue
 - [CONTRIBUTING.md](CONTRIBUTING.md)
 - [docs/glasslab-v2/current/README.md](docs/glasslab-v2/current/README.md)
 - [docs/glasslab-v2/canonical-stack-2026-04.md](docs/glasslab-v2/canonical-stack-2026-04.md)

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,51 @@
+# Glasslab Work Queue
+
+Last reviewed: 2026-08-06
+
+GitHub Issues are the authoritative backlog. This file is a compact priority
+index for humans and coding agents arriving in the repository; it must not
+duplicate complete task specifications or maintain an independent status.
+
+Current issues:
+
+- [all open work](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues)
+- [ready work](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues?q=is%3Aissue%20state%3Aopen%20label%3Astate%3Aready)
+- [newcomer work](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
+
+## P0: Restore The End-To-End Research Loop
+
+- [#92 Add terminal research-run checkpoint retry](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/92)
+- [#100 Complete corrected Wine clustering run](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/100), blocked by #92
+
+## P1: Make Operation Observable And Faster
+
+- [#95 Expose structured research-run turn inspection](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/95)
+- [#94 Add Discord research run status and discovery commands](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/94)
+- [#93 Compact research-agent evidence prompts](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/93)
+- [#99 Add research runtime storage retention and cache cleanup](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/99)
+
+## P1: Validate General Research Tasks
+
+- [#98 Validate an arbitrary-dataset research workflow end to end](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/98)
+- [#101 Complete Fashion-MNIST compatibility run](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/101)
+- [#96 Evaluate Hermes as a research-agent runtime adapter](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/96)
+
+## P2: Durability And Maintenance
+
+- [#97 Plan PostgreSQL migration for the research orchestrator](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/97)
+- [#102 Consolidate current docs and triage legacy issues](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/102)
+
+## Maintenance Rule
+
+When work is discovered, create or update a GitHub issue before changing this
+index. The issue must contain scope, acceptance criteria, relevant area and
+priority labels, dependencies, and enough context for a new contributor to
+start without reconstructing chat history.
+
+When work starts, comment with the intended approach and link the branch or
+pull request. Pull requests should use `Closes #<issue>` when they fully satisfy
+the issue. Close abandoned work with a reason rather than deleting it. Update
+this file only when the short prioritized index changes.
+
+Completed work belongs in release notes, design docs, or the issue history,
+not in a growing completed-items section here.


### PR DESCRIPTION
## Summary

- add `HANDOFF.md` as a compact current implementation and live-operations checkpoint for switching agents
- make GitHub Issues the authoritative backlog, with `TODO.md` as a short priority index
- add a structured Glasslab work-item issue form
- document issue ownership, labeling, branch, and closure conventions
- link the handoff and queue from the existing contributor entry points

## Backlog reset

- created current issues #92-#102 with priority, state, area, scope, and acceptance criteria
- closed obsolete issues #60-#76 with explanatory supersession comments while preserving their history
- added `priority:p0`, `priority:p1`, `priority:p2`, and `area:research-orchestrator` labels

## Validation

- `./scripts/check-before-push.sh --docs`
- `git diff --check`

Refs #102