### PR TITLE
Recover missing Honeydew contract proposals

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,7 @@ Current issues:
 
 ## P0: Restore The End-To-End Research Loop
 
+- [#104 Prevent missing Honeydew contract metadata from failing a run](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/104)
 - [#92 Add terminal research-run checkpoint retry](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/92)
 - [#100 Complete corrected Wine clustering run](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/100), blocked by #92
 

--- a/services/research-orchestrator/app/engine.py
+++ b/services/research-orchestrator/app/engine.py
@@ -28,6 +28,7 @@ from .schemas import (
     ArtifactRecord,
     ContractCandidateRequest,
     EvaluationContractDescriptor,
+    EvaluationContractProposal,
     ExperimentMatrix,
     JOB_TERMINAL_STATUSES,
     JobRecord,
@@ -1099,10 +1100,81 @@ class ResearchOrchestrator:
                 event_type='agent.file_repair_completed',
                 payload={'path': protocol_files[0].path},
             )
+        resolved_contract = self.contracts.resolve(
+            run.evaluation_contract_id,
+            run.evaluation_contract_version,
+        )
+        descriptor = resolved_contract.descriptor
         proposal = result.evaluation_contract_proposal
-        if proposal is None:
-            raise WorkflowError(
-                'Honeydew must return an evaluation contract proposal'
+        proposal_turn_id = turn.turn_id
+        proposal_origin = 'honeydew'
+        legacy_bound_task = bool(
+            run.task_definition
+            and run.task_definition.get('compilation_source') == 'legacy'
+        )
+        if proposal is None and legacy_bound_task:
+            proposal = self._proposal_from_bound_contract(descriptor)
+            proposal_origin = 'installed_contract'
+            self._event(
+                run_id,
+                source='orchestrator',
+                event_type='contract.proposal_bound',
+                payload={
+                    'turn_id': turn.turn_id,
+                    'contract_id': descriptor.contract_id,
+                    'contract_version': descriptor.version,
+                    'reason': (
+                        'The imported legacy task already has an immutable '
+                        'repository-controlled evaluation contract.'
+                    ),
+                },
+            )
+        elif proposal is None:
+            self._event(
+                run_id,
+                source='orchestrator',
+                event_type='agent.output_rejected',
+                payload={
+                    'turn_id': turn.turn_id,
+                    'expected_field': 'evaluation_contract_proposal',
+                    'repair_attempted': True,
+                },
+            )
+            proposal_turn, repaired = self._run_agent_turn(
+                run_id=run_id,
+                agent=AgentName.HONEYDEW,
+                prompt=(
+                    'Focused structured-output repair. Your protocol was '
+                    'written successfully, but the prior response omitted '
+                    '`evaluation_contract_proposal`. Do not edit program.md '
+                    'or request actions. Return kind `protocol_draft` and '
+                    'populate evaluation_contract_proposal with the scientific '
+                    'evaluator type, primary metric and direction, minimum '
+                    'meaningful effect, guardrails, required artifacts, budget '
+                    'policy, resource ceilings, and rationale. Do not include '
+                    'executable paths, commands, images, or checksums.'
+                ),
+                expected_kind=TurnKind.PROTOCOL_DRAFT,
+                input_event={
+                    'repair': 'missing_evaluation_contract_proposal',
+                    'protocol_turn_id': turn.turn_id,
+                },
+            )
+            proposal = repaired.evaluation_contract_proposal
+            if proposal is None or repaired.requested_actions:
+                raise WorkflowError(
+                    'Honeydew contract-proposal repair did not return the '
+                    'required bounded proposal'
+                )
+            proposal_turn_id = proposal_turn.turn_id
+            self._event(
+                run_id,
+                source='honeydew',
+                event_type='agent.output_repaired',
+                payload={
+                    'turn_id': proposal_turn.turn_id,
+                    'field': 'evaluation_contract_proposal',
+                },
             )
         proposal_resources = proposal.resource_constraints
         if (
@@ -1153,11 +1225,6 @@ class ResearchOrchestrator:
                 'turn_id': turn.turn_id,
             },
         )
-        resolved_contract = self.contracts.resolve(
-            run.evaluation_contract_id,
-            run.evaluation_contract_version,
-        )
-        descriptor = resolved_contract.descriptor
         technical_primary_metric = str(
             descriptor.manifest.get('primary_metric', '')
         )
@@ -1217,7 +1284,8 @@ class ResearchOrchestrator:
             digest=proposal_digest,
             metadata={
                 'path': str(proposal_path),
-                'turn_id': turn.turn_id,
+                'turn_id': proposal_turn_id,
+                'origin': proposal_origin,
                 'proposal': proposal_payload,
                 'technical_binding': technical_binding,
             },
@@ -1231,7 +1299,8 @@ class ResearchOrchestrator:
                 'uri': proposal_uri,
                 'path': str(proposal_path),
                 'sha256': proposal_digest,
-                'turn_id': turn.turn_id,
+                'turn_id': proposal_turn_id,
+                'origin': proposal_origin,
                 'proposal': proposal_payload,
                 'technical_binding': technical_binding,
             },
@@ -1242,6 +1311,34 @@ class ResearchOrchestrator:
             reason='Human approval is required before implementation.',
         )
         self._transition(run_id, RunState.AWAITING_PROTOCOL_APPROVAL)
+
+    @staticmethod
+    def _proposal_from_bound_contract(
+        descriptor: EvaluationContractDescriptor,
+    ) -> EvaluationContractProposal:
+        """Project an immutable legacy contract into the scientific proposal."""
+        resources = descriptor.resource_constraints
+        return EvaluationContractProposal.model_validate(
+            {
+                'evaluator_type': descriptor.contract_id,
+                'primary_metric': {
+                    'name': descriptor.manifest['primary_metric'],
+                    'direction': descriptor.manifest[
+                        'primary_metric_direction'
+                    ],
+                    'minimum_effect': 0.0,
+                },
+                'guardrails': [],
+                'required_artifacts': descriptor.required_artifacts,
+                'budget_mode': 'wallclock',
+                'max_wallclock_minutes': resources.wallclock_minutes,
+                'resource_constraints': resources.model_dump(mode='json'),
+                'rationale': (
+                    'This imported task is bound to an immutable '
+                    'repository-controlled evaluation contract.'
+                ),
+            }
+        )
 
     def approve_action(
         self,

--- a/services/research-orchestrator/tests/test_workflow.py
+++ b/services/research-orchestrator/tests/test_workflow.py
@@ -321,6 +321,31 @@ class MissingProtocolThenRepairRuntime(ScriptedMockRuntime):
         return result
 
 
+class MissingContractProposalThenRepairRuntime(ScriptedMockRuntime):
+    def __init__(self, *, runner_image: str) -> None:
+        super().__init__(runner_image=runner_image)
+        self.removed_first_proposal = False
+
+    def run_turn(self, **kwargs):
+        prompt = kwargs['prompt']
+        if 'Focused structured-output repair' in prompt:
+            return super().run_turn(
+                **{
+                    **kwargs,
+                    'prompt': 'Draft a concrete program.md',
+                }
+            )
+        result, message_id = super().run_turn(**kwargs)
+        if (
+            kwargs['agent'] == AgentName.HONEYDEW
+            and 'Draft a concrete program.md' in prompt
+            and not self.removed_first_proposal
+        ):
+            result.evaluation_contract_proposal = None
+            self.removed_first_proposal = True
+        return result, message_id
+
+
 class PauseDuringImplementationRuntime(ScriptedMockRuntime):
     def __init__(self, *, runner_image: str) -> None:
         super().__init__(runner_image=runner_image)
@@ -800,6 +825,53 @@ def test_missing_honeydew_protocol_file_gets_one_focused_repair(
     assert 'agent.file_repair_requested' in event_types
     assert 'agent.file_repair_completed' in event_types
     assert runtime.turn_counts[AgentName.HONEYDEW] == 2
+
+
+def test_missing_contract_proposal_gets_one_focused_repair(
+    orchestrator_bundle,
+) -> None:
+    _, store, _, _, engine = orchestrator_bundle
+    runtime = MissingContractProposalThenRepairRuntime(runner_image=RUNNER_IMAGE)
+    engine.runtime = runtime
+
+    run = engine.create_run(
+        RunCreateRequest(objective='Repair missing contract proposal metadata.')
+    )
+
+    assert run.state == RunState.AWAITING_PROTOCOL_APPROVAL
+    proposal = next(
+        artifact
+        for artifact in store.list_artifacts(run.run_id)
+        if artifact.type == 'evaluation_contract_proposal'
+    )
+    assert proposal.metadata['origin'] == 'honeydew'
+    event_types = {
+        event.event_type for event in store.list_events(run.run_id)
+    }
+    assert 'agent.output_rejected' in event_types
+    assert 'agent.output_repaired' in event_types
+    assert runtime.turn_counts[AgentName.HONEYDEW] == 2
+
+
+def test_bound_legacy_contract_can_supply_missing_proposal(
+    orchestrator_bundle,
+) -> None:
+    _, _, _, _, engine = orchestrator_bundle
+    descriptor = engine.contracts.resolve(
+        'ml-benchmark-adult-income-v1',
+        '1.1.0',
+    ).descriptor
+
+    proposal = engine._proposal_from_bound_contract(descriptor)
+
+    assert proposal.evaluator_type == descriptor.contract_id
+    assert proposal.primary_metric.name == 'rubric_score'
+    assert proposal.primary_metric.direction == 'maximize'
+    assert proposal.required_artifacts == descriptor.required_artifacts
+    assert proposal.max_wallclock_minutes == 60
+    assert proposal.resource_constraints.model_dump() == (
+        descriptor.resource_constraints.model_dump()
+    )
 
 
 def test_idempotent_job_submission(orchestrator_bundle) -> None:


### PR DESCRIPTION
## Summary

- derive contract proposal metadata from the immutable installed descriptor for legacy imported tasks
- give open-ended Honeydew turns one focused repair attempt when structured contract metadata is omitted
- record whether proposal metadata came from Honeydew or deterministic contract binding
- add regression coverage for both recovery paths

## Live failure

Run `4f4c15520f1d40cf82b29a7147233e25` wrote and reread `program.md`, then failed because the otherwise valid structured response omitted `evaluation_contract_proposal`.

## Validation

- research-orchestrator: `100 passed in 41.28s`
- `./scripts/check-before-push.sh --python-core`
  - workflow-api core: `159 passed`
  - evaluator: `6 passed`
  - research-orchestrator: `100 passed`

Closes #104