### PR TITLE
Supervise two-node exo with launchd

### DIFF
--- a/docs/exo-golden-path.md
+++ b/docs/exo-golden-path.md
@@ -1,203 +1,139 @@
 # exo Golden Path
 
-Last updated: 2026-04-21
+Last updated: 2026-08-06
 
-This is the known-good recovery path for the two-node exo + Thunderbolt RDMA + OpenCode setup on the two Mac Studios.
+This is the current two-node exo, Thunderbolt RDMA, Qwen, and OpenCode path.
+The older `.21` and `.19` topology is retired from this runbook.
 
-## 0. Optional: make sure both Macs are on the known-good exo version
+## Topology
 
-Run on both Macs:
+| Role | LAN | Thunderbolt | exo role |
+| --- | --- | --- | --- |
+| API/master | `192.168.1.17` | `192.168.0.2/30` | forced master and OpenAI-compatible API |
+| Worker | `192.168.1.18` | `192.168.0.1/30` | worker bootstrapped directly to `.17` |
+
+Both nodes use:
+
+- exo tree: `/Users/glasslab/exo`
+- namespace: `glasslab-rdma-prod`
+- API port: `52415`
+- libp2p port: `54216`
+- RDMA interface: `rdma_en5`
+
+The approved OpenCode model is
+`mlx-community/Qwen3-Coder-Next-4bit`. Its placement must be two-node
+`Pipeline + MlxJaccl`.
+
+## Supervised Startup
+
+System `LaunchDaemon` jobs own exo. Do not start another copy with `nohup`.
+
+On `.17`:
+
+- `com.glasslab.exo` supervises the exo master/API.
+- `com.glasslab.exo-reconcile` waits for both RDMA-connected nodes and restores
+  the approved Qwen placement when no active instance exists.
+
+On `.18`:
+
+- `com.glasslab.exo` supervises the worker.
+- the worker obtains `.17`'s current peer ID from the master API and uses an
+  explicit Thunderbolt bootstrap multiaddress.
+
+`KeepAlive` restarts a process that exits. Both jobs run as the `glasslab`
+account at boot and do not require an interactive login.
+
+## Install Or Update
+
+Copy `scripts/macos/` to each Mac and run:
 
 ```bash
-cd ~/exo
-git fetch origin
-git reset --hard origin/main
-uv sync
-git rev-parse --short HEAD
+sudo ./scripts/macos/install-exo-launchd.sh 18  # on .18 first
+sudo ./scripts/macos/install-exo-launchd.sh 17  # on .17 second
 ```
 
-Known-good commit from the restored state: `49670c86`.
+Installing `.18` first lets the worker wait for the deterministic master while
+`.17` is restarted.
 
-## 1. Verify Thunderbolt RDMA on both Macs
+## Validate
 
-On `.21`:
+Check the daemons:
+
+```bash
+sudo launchctl print system/com.glasslab.exo
+sudo launchctl print system/com.glasslab.exo-reconcile  # .17 only
+```
+
+Check the physical path on both Macs:
 
 ```bash
 ifconfig en5
-networksetup -getinfo "EXO Thunderbolt 4"
 ibv_devices
-route -n get 192.168.0.2
 ```
 
-On `.19`:
+Expected addresses:
 
-```bash
-ifconfig en5
-networksetup -getinfo "EXO Thunderbolt 4"
-ibv_devices
-route -n get 192.168.0.1
+```text
+.17 en5: 192.168.0.2
+.18 en5: 192.168.0.1
 ```
 
-What you want:
-
-- `.21` has `192.168.0.1/30` on `en5`
-- `.19` has `192.168.0.2/30` on `en5`
-- `rdma_en5` exists on both Macs
-
-## 2. If either Mac lost its Thunderbolt IP, rebind it
-
-On `.21` only:
+Check the authoritative state on `.17`:
 
 ```bash
-sudo ifconfig en5 inet 192.168.0.1 netmask 255.255.255.252 up
-ifconfig en5
+curl -fsS http://127.0.0.1:52415/state | jq '{
+  nodes: (.topology.nodes | length),
+  connections: .topology.connections,
+  instances: (.instances | keys)
+}'
 ```
 
-On `.19` only:
+Run a real completion:
 
 ```bash
-sudo ifconfig en5 inet 192.168.0.2 netmask 255.255.255.252 up
-ifconfig en5
-```
-
-## 3. Verify the point-to-point link works both ways
-
-From `.21`:
-
-```bash
-ping -S 192.168.0.1 -c 5 192.168.0.2
-```
-
-From `.19`:
-
-```bash
-ping -S 192.168.0.2 -c 5 192.168.0.1
-```
-
-These need to succeed before you bother with exo.
-
-## 4. Start exo once on each Mac
-
-On `.21`:
-
-```bash
-cd ~/exo
-nohup caffeinate -dimsu env EXO_LIBP2P_NAMESPACE=glasslab-rdma-test EXO_FAST_SYNCH=1 uv run exo > ~/exo-21.log 2>&1 < /dev/null &
-```
-
-On `.19`:
-
-```bash
-cd ~/exo
-nohup caffeinate -dimsu env EXO_LIBP2P_NAMESPACE=glasslab-rdma-test EXO_FAST_SYNCH=1 uv run exo > ~/exo-19.log 2>&1 < /dev/null &
-```
-
-Those are the exact environment settings from the working restore.
-
-## 5. On `.21`, run the health/model preflight
-
-```bash
-~/opencode-with-exo.sh --dry-run
-```
-
-Expected result:
-
-- 2-node cluster
-- RDMA edges on `rdma_en5`
-- usable 2-node `MlxJaccl` preview
-- active instance or successful readiness check
-
-## 6. If dry-run passes, use the model through OpenCode
-
-```bash
-opencode-with-exo
-```
-
-Or with a one-shot prompt:
-
-```bash
-opencode-with-exo "Summarize this repository and suggest 3 improvements."
-```
-
-## 7. Direct smoke test, if you want to verify the model manually
-
-From `.21`:
-
-```bash
-curl -X POST http://127.0.0.1:52415/v1/chat/completions \
+curl -fsS http://127.0.0.1:52415/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model":"mlx-community/Qwen3-Coder-Next-4bit","messages":[{"role":"user","content":"Reply with exactly OK."}],"max_tokens":8,"stream":false}'
+  -d '{"model":"mlx-community/Qwen3-Coder-Next-4bit","messages":[{"role":"user","content":"Reply exactly: OK"}],"max_tokens":8}'
 ```
 
-Expected result: HTTP `200` and content `OK`.
+## OpenCode
 
-## 8. Handy fallback commands
-
-Health check only:
+Use OpenCode from `.17`, where its provider points to the local exo API:
 
 ```bash
-exo-rdma-health-check
+ssh glasslab-17
+cd ~/cluster-config
+opencode -m exo/mlx-community/Qwen3-Coder-Next-4bit
 ```
 
-Bring model up directly:
+The model reconciler may need a short interval after both Macs boot before the
+instance is ready.
+
+## Logs And Recovery
+
+Logs are retained outside `/tmp`:
+
+```text
+/Users/glasslab/Library/Logs/glasslab-exo.log
+/Users/glasslab/Library/Logs/glasslab-exo.error.log
+/Users/glasslab/Library/Logs/glasslab-exo-reconcile.log
+/Users/glasslab/Library/Logs/glasslab-exo-reconcile.error.log
+```
+
+Restart a service without creating an unmanaged process:
 
 ```bash
-exo-bringup-model --model mlx-community/Qwen3-Coder-Next-4bit
+sudo launchctl kickstart -k system/com.glasslab.exo
+sudo launchctl kickstart -k system/com.glasslab.exo-reconcile  # .17 only
 ```
 
-Recover a node and start exo:
+If the Thunderbolt interface is absent or inactive, repair that operating
+system network state first. `launchd` deliberately waits rather than attempting
+privileged network reconfiguration.
 
-On `.21`:
+## Remaining Limitation
 
-```bash
-exo-node-recover --self 192.168.0.1 --peer 192.168.0.2 --start-exo
-```
-
-On `.19`:
-
-```bash
-exo-node-recover --self 192.168.0.2 --peer 192.168.0.1 --start-exo
-```
-
-Those helper scripts are installed both in `~` and on `PATH` on both Macs.
-
-## 9. Minimal “do this after reboot” version
-
-On both Macs:
-
-```bash
-ifconfig en5
-networksetup -getinfo "EXO Thunderbolt 4"
-ibv_devices
-```
-
-If needed:
-
-```bash
-sudo ifconfig en5 inet 192.168.0.1 netmask 255.255.255.252 up   # .21
-sudo ifconfig en5 inet 192.168.0.2 netmask 255.255.255.252 up   # .19
-```
-
-Then:
-
-```bash
-ping -S 192.168.0.1 -c 5 192.168.0.2   # on .21
-ping -S 192.168.0.2 -c 5 192.168.0.1   # on .19
-```
-
-Then:
-
-```bash
-cd ~/exo
-nohup caffeinate -dimsu env EXO_LIBP2P_NAMESPACE=glasslab-rdma-test EXO_FAST_SYNCH=1 uv run exo > ~/exo-21.log 2>&1 < /dev/null &
-nohup caffeinate -dimsu env EXO_LIBP2P_NAMESPACE=glasslab-rdma-test EXO_FAST_SYNCH=1 uv run exo > ~/exo-19.log 2>&1 < /dev/null &
-```
-
-Then on `.21`:
-
-```bash
-~/opencode-with-exo.sh --dry-run
-opencode-with-exo
-```
-
-This is the exact path that restored the 2-node exo cluster with Thunderbolt RDMA and a working `mlx-community/Qwen3-Coder-Next-4bit` serving stack.
+The LAN addresses `.17` and `.18` are currently DHCP leases from
+`192.168.1.100`. Reserve their Ethernet MAC addresses on that DHCP server. Exo
+itself communicates over the static Thunderbolt addresses, so a changed LAN
+lease affects SSH aliases but not the internal model transport.

--- a/scripts/macos/com.glasslab.exo-17.plist
+++ b/scripts/macos/com.glasslab.exo-17.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.glasslab.exo</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/libexec/glasslab-exo-run</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>GLASSLAB_EXO_ROLE</key><string>master</string>
+      <key>GLASSLAB_EXO_SELF_IP</key><string>192.168.0.2</string>
+      <key>GLASSLAB_EXO_PEER_IP</key><string>192.168.0.1</string>
+      <key>GLASSLAB_EXO_HOME</key><string>/Users/glasslab/.exo-rdma-17</string>
+      <key>GLASSLAB_EXO_NAMESPACE</key><string>glasslab-rdma-prod</string>
+    </dict>
+    <key>UserName</key><string>glasslab</string>
+    <key>GroupName</key><string>staff</string>
+    <key>WorkingDirectory</key><string>/Users/glasslab/exo</string>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <key>ThrottleInterval</key><integer>15</integer>
+    <key>ProcessType</key><string>Adaptive</string>
+    <key>StandardOutPath</key><string>/Users/glasslab/Library/Logs/glasslab-exo.log</string>
+    <key>StandardErrorPath</key><string>/Users/glasslab/Library/Logs/glasslab-exo.error.log</string>
+  </dict>
+</plist>

--- a/scripts/macos/com.glasslab.exo-18.plist
+++ b/scripts/macos/com.glasslab.exo-18.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.glasslab.exo</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/libexec/glasslab-exo-run</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>GLASSLAB_EXO_ROLE</key><string>worker</string>
+      <key>GLASSLAB_EXO_SELF_IP</key><string>192.168.0.1</string>
+      <key>GLASSLAB_EXO_PEER_IP</key><string>192.168.0.2</string>
+      <key>GLASSLAB_EXO_HOME</key><string>/Users/glasslab/.exo-rdma-18</string>
+      <key>GLASSLAB_EXO_NAMESPACE</key><string>glasslab-rdma-prod</string>
+    </dict>
+    <key>UserName</key><string>glasslab</string>
+    <key>GroupName</key><string>staff</string>
+    <key>WorkingDirectory</key><string>/Users/glasslab/exo</string>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <key>ThrottleInterval</key><integer>15</integer>
+    <key>ProcessType</key><string>Adaptive</string>
+    <key>StandardOutPath</key><string>/Users/glasslab/Library/Logs/glasslab-exo.log</string>
+    <key>StandardErrorPath</key><string>/Users/glasslab/Library/Logs/glasslab-exo.error.log</string>
+  </dict>
+</plist>

--- a/scripts/macos/com.glasslab.exo-reconcile.plist
+++ b/scripts/macos/com.glasslab.exo-reconcile.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.glasslab.exo-reconcile</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/libexec/glasslab-exo-reconcile</string>
+    </array>
+    <key>UserName</key><string>glasslab</string>
+    <key>GroupName</key><string>staff</string>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <key>ThrottleInterval</key><integer>15</integer>
+    <key>ProcessType</key><string>Background</string>
+    <key>StandardOutPath</key><string>/Users/glasslab/Library/Logs/glasslab-exo-reconcile.log</string>
+    <key>StandardErrorPath</key><string>/Users/glasslab/Library/Logs/glasslab-exo-reconcile.error.log</string>
+  </dict>
+</plist>

--- a/scripts/macos/glasslab-exo-reconcile.sh
+++ b/scripts/macos/glasslab-exo-reconcile.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+set -euo pipefail
+
+API_BASE="${GLASSLAB_EXO_API_BASE:-http://127.0.0.1:52415}"
+MODEL="${GLASSLAB_EXO_MODEL:-mlx-community/Qwen3-Coder-Next-4bit}"
+RDMA_IFACE="${GLASSLAB_EXO_RDMA_IFACE:-rdma_en5}"
+INTERVAL="${GLASSLAB_EXO_RECONCILE_INTERVAL:-30}"
+
+log() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+needs_probe=1
+placement_grace_until=0
+
+while true; do
+  state=$(/usr/bin/curl -fsS --max-time 5 "${API_BASE}/state" 2>/dev/null || true)
+  if [[ -z "$state" ]]; then
+    log "master API unavailable"
+    sleep "$INTERVAL"
+    continue
+  fi
+
+  if ! printf '%s' "$state" | /usr/bin/jq -e --arg iface "$RDMA_IFACE" '
+    (.topology.nodes | length) == 2 and
+    ([
+      .topology.connections
+      | to_entries[]?.value
+      | to_entries[]?.value[]?
+      | select(.sourceRdmaIface? == $iface and .sinkRdmaIface? == $iface)
+    ] | length) >= 2
+  ' >/dev/null; then
+    needs_probe=1
+    log "waiting for the two-node ${RDMA_IFACE} topology"
+    sleep "$INTERVAL"
+    continue
+  fi
+
+  instance_ids=$(printf '%s' "$state" | /usr/bin/jq -r --arg model "$MODEL" '
+    .instances
+    | to_entries[]?
+    | select([.value | .. | strings | select(. == $model)] | length > 0)
+    | .key
+  ')
+
+  if [[ -n "$instance_ids" ]]; then
+    if (( needs_probe == 0 )); then
+      sleep "$INTERVAL"
+      continue
+    fi
+
+    probe_payload=$(/usr/bin/jq -nc --arg model "$MODEL" '{
+      model: $model,
+      messages: [{role: "user", content: "ping"}],
+      max_tokens: 1,
+      temperature: 0
+    }')
+    probe_code=$(/usr/bin/curl -sS --max-time 120 -o /dev/null -w '%{http_code}' \
+      -H 'Content-Type: application/json' \
+      --data-binary "$probe_payload" \
+      "${API_BASE}/v1/chat/completions" || true)
+
+    if [[ "$probe_code" == "200" ]]; then
+      needs_probe=0
+      placement_grace_until=0
+      log "verified inference for ${MODEL}"
+      sleep "$INTERVAL"
+      continue
+    fi
+
+    now=$(date +%s)
+    if (( now < placement_grace_until )); then
+      log "placement is still starting; inference returned HTTP ${probe_code}"
+      sleep "$INTERVAL"
+      continue
+    fi
+
+    log "removing stale instance after inference returned HTTP ${probe_code}"
+    while IFS= read -r instance_id; do
+      [[ -n "$instance_id" ]] || continue
+      /usr/bin/curl -fsS --max-time 30 -X DELETE \
+        "${API_BASE}/instance/${instance_id}" >/dev/null || true
+    done <<< "$instance_ids"
+    sleep "$INTERVAL"
+    continue
+  fi
+
+  previews=$(/usr/bin/curl -fsS --max-time 15 --get \
+    --data-urlencode "model_id=${MODEL}" \
+    "${API_BASE}/instance/previews" 2>/dev/null || true)
+  instance=$(printf '%s' "$previews" | /usr/bin/jq -c '
+    first(
+      .previews[]?
+      | select(
+          .error == null and
+          .sharding == "Pipeline" and
+          .instance_meta == "MlxJaccl" and
+          (.memory_delta_by_node | length) == 2
+        )
+      | .instance
+    )
+  ' 2>/dev/null || true)
+
+  if [[ -z "$instance" || "$instance" == "null" ]]; then
+    log "no approved two-node Pipeline + MlxJaccl placement is available"
+    sleep "$INTERVAL"
+    continue
+  fi
+
+  payload=$(/usr/bin/jq -nc --argjson instance "$instance" '{instance: $instance}')
+  if /usr/bin/curl -fsS --max-time 30 -X POST \
+    -H 'Content-Type: application/json' \
+    --data-binary "$payload" \
+    "${API_BASE}/instance" >/dev/null; then
+    needs_probe=1
+    placement_grace_until=$(($(date +%s) + 180))
+    log "submitted two-node placement for ${MODEL}"
+  else
+    log "failed to submit placement for ${MODEL}"
+  fi
+
+  sleep "$INTERVAL"
+done

--- a/scripts/macos/glasslab-exo-run.sh
+++ b/scripts/macos/glasslab-exo-run.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+ROLE="${GLASSLAB_EXO_ROLE:?GLASSLAB_EXO_ROLE is required}"
+SELF_IP="${GLASSLAB_EXO_SELF_IP:?GLASSLAB_EXO_SELF_IP is required}"
+PEER_IP="${GLASSLAB_EXO_PEER_IP:?GLASSLAB_EXO_PEER_IP is required}"
+EXO_HOME="${GLASSLAB_EXO_HOME:?GLASSLAB_EXO_HOME is required}"
+EXO_REPO="${GLASSLAB_EXO_REPO:-/Users/glasslab/exo}"
+EXO_BIN="${EXO_REPO}/.venv/bin/exo"
+API_PORT="${GLASSLAB_EXO_API_PORT:-52415}"
+LIBP2P_PORT="${GLASSLAB_EXO_LIBP2P_PORT:-54216}"
+NAMESPACE="${GLASSLAB_EXO_NAMESPACE:-glasslab-rdma-prod}"
+IFACE="${GLASSLAB_EXO_IFACE:-en5}"
+
+log() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+if [[ "$ROLE" != "master" && "$ROLE" != "worker" ]]; then
+  log "invalid role: ${ROLE}"
+  exit 2
+fi
+
+if [[ ! -x "$EXO_BIN" ]]; then
+  log "exo executable not found: ${EXO_BIN}"
+  exit 3
+fi
+
+mkdir -p "$EXO_HOME"
+
+until /sbin/ifconfig "$IFACE" 2>/dev/null | /usr/bin/grep -q "inet ${SELF_IP} "; do
+  log "waiting for ${SELF_IP} on ${IFACE}"
+  sleep 10
+done
+
+until /sbin/ping -S "$SELF_IP" -c 1 -t 3 "$PEER_IP" >/dev/null 2>&1; do
+  log "waiting for Thunderbolt peer ${PEER_IP}"
+  sleep 10
+done
+
+common_args=(
+  -vv
+  --libp2p-port "$LIBP2P_PORT"
+  --fast-synch
+)
+
+export EXO_HOME
+export EXO_LIBP2P_NAMESPACE="$NAMESPACE"
+export EXO_FAST_SYNCH=1
+export EXO_INFO_DISK_INTERVAL=60
+
+cd "$EXO_REPO"
+
+if [[ "$ROLE" == "master" ]]; then
+  log "starting deterministic master on ${SELF_IP}"
+  exec /usr/bin/caffeinate -dimsu "$EXO_BIN" \
+    "${common_args[@]}" \
+    -m \
+    --api-port "$API_PORT"
+fi
+
+master_id=""
+until master_id=$(/usr/bin/curl -fsS --max-time 5 \
+  "http://${PEER_IP}:${API_PORT}/node_id" 2>/dev/null | /usr/bin/tr -d '"[:space:]') && \
+  [[ -n "$master_id" ]]; do
+  log "waiting for master API at ${PEER_IP}:${API_PORT}"
+  sleep 10
+done
+
+bootstrap_peer="/ip4/${PEER_IP}/tcp/${LIBP2P_PORT}/p2p/${master_id}"
+log "starting worker with bootstrap peer ${bootstrap_peer}"
+exec /usr/bin/caffeinate -dimsu "$EXO_BIN" \
+  "${common_args[@]}" \
+  --no-api \
+  --bootstrap-peers "$bootstrap_peer"

--- a/scripts/macos/install-exo-launchd.sh
+++ b/scripts/macos/install-exo-launchd.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+ROLE="${1:-}"
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+if [[ "$ROLE" != "17" && "$ROLE" != "18" ]]; then
+  echo "Usage: sudo $0 17|18" >&2
+  exit 2
+fi
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "Run this installer with sudo." >&2
+  exit 2
+fi
+
+if [[ ! -x /Users/glasslab/exo/.venv/bin/exo ]]; then
+  echo "Missing /Users/glasslab/exo/.venv/bin/exo" >&2
+  exit 3
+fi
+
+install -d -o glasslab -g staff /Users/glasslab/Library/Logs
+install -d -o root -g wheel /usr/local/libexec
+install -o root -g wheel -m 0755 \
+  "${SCRIPT_DIR}/glasslab-exo-run.sh" \
+  /usr/local/libexec/glasslab-exo-run
+install -o root -g wheel -m 0755 \
+  "${SCRIPT_DIR}/glasslab-exo-reconcile.sh" \
+  /usr/local/libexec/glasslab-exo-reconcile
+install -o root -g wheel -m 0644 \
+  "${SCRIPT_DIR}/com.glasslab.exo-${ROLE}.plist" \
+  /Library/LaunchDaemons/com.glasslab.exo.plist
+
+plutil -lint /Library/LaunchDaemons/com.glasslab.exo.plist
+
+launchctl bootout system/com.glasslab.exo 2>/dev/null || true
+launchctl bootout system/com.glasslab.exo-reconcile 2>/dev/null || true
+sleep 2
+pkill -u glasslab -f '/Users/glasslab/exo/.venv/bin/python3' 2>/dev/null || true
+pkill -u glasslab -f 'caffeinate.*exo' 2>/dev/null || true
+
+if [[ "$ROLE" == "17" ]]; then
+  install -o root -g wheel -m 0644 \
+    "${SCRIPT_DIR}/com.glasslab.exo-reconcile.plist" \
+    /Library/LaunchDaemons/com.glasslab.exo-reconcile.plist
+  plutil -lint /Library/LaunchDaemons/com.glasslab.exo-reconcile.plist
+else
+  rm -f /Library/LaunchDaemons/com.glasslab.exo-reconcile.plist
+fi
+
+launchctl bootstrap system /Library/LaunchDaemons/com.glasslab.exo.plist
+launchctl enable system/com.glasslab.exo
+launchctl kickstart -k system/com.glasslab.exo
+
+if [[ "$ROLE" == "17" ]]; then
+  launchctl bootstrap system /Library/LaunchDaemons/com.glasslab.exo-reconcile.plist
+  launchctl enable system/com.glasslab.exo-reconcile
+  launchctl kickstart -k system/com.glasslab.exo-reconcile
+fi
+
+launchctl print system/com.glasslab.exo | grep -E 'state =|pid =|last exit code ='


### PR DESCRIPTION
## Summary
- run `.17` as the deterministic exo master/API and `.18` as its bootstrapped worker
- supervise both processes with system LaunchDaemons
- reconcile the approved two-node Qwen Pipeline + MlxJaccl placement on `.17`
- replace the stale `.21`/`.19` manual-start runbook with the current `.17`/`.18` path

## Live validation
- deployed both LaunchDaemons to `.17` and `.18`
- verified two nodes and two `rdma_en5` topology edges
- verified automatic Qwen placement after a full service restart
- restarted the `.18` worker and verified topology and inference recovered
- verified OpenCode response: `supervised recovery works`

## Local validation
- `bash -n` for all shell scripts
- `git diff --check`
- `plutil -lint` on all plists on macOS

## Remaining limitation
LAN DHCP reservations for `.17` and `.18` still need to be configured on `192.168.1.100`; exo transport itself uses the static Thunderbolt addresses.