### PR TITLE
Fix Honeydew hallucinating expected_sha256 for source_url assetsAdd field description to prevent Honeydew from hallucinating expected…

### DIFF
--- a/services/research-orchestrator/app/schemas.py
+++ b/services/research-orchestrator/app/schemas.py
@@ -201,6 +201,12 @@ class TaskAssetProposal(BaseModel):
     expected_sha256: str | None = Field(
         default=None,
         pattern=r'^[a-f0-9]{64}$',
+        description=(
+            'Only set if a verified SHA-256 checksum is already known for '
+            'this asset. Omit (leave null) for source_url assets, '
+            'multi-file or sharded datasets, or any case where no single '
+            'verified checksum exists. Do not invent or compute a value.'
+        ),
     )
     contains_labels: bool = False
 


### PR DESCRIPTION

Bug: /task-start preflight rejects valid task submissions using a public source_url dataset asset (no upload, no known checksum) with:

task_spec_proposal.assets.0.expected_sha256: String should match pattern '^[a-f0-9]{64}$'

This happens even when the submitted problem.md never mentions a checksum, the invalid value is being generated by Honeydew's OpenCode output, not supplied by the human.

Root cause: expected_sha256 is correctly optional in the schema (schemas.py, TaskAssetProposal) , default=None, and every usage site (task_bundles.py, datasets.py) guards with if expected_sha256 and ..., so omitting it is completely valid. TaskAssetProposal.validate_asset_source also confirms assets use either source_url or approved_uri, never both, a source_url asset was never meant to carry a checksum here.

The model sees only the raw, auto-generated JSON schema (AgentTurnResult.model_json_schema() in opencode_runtime.py) with no field-level guidance. prompts/honeydew.md describes Honeydew's role/boundaries generally but says nothing about individual TaskAssetProposal fields. When Honeydew fills the field with an invalid guess and validation fails, the existing repair loop sends back the raw Pydantic error text (the pattern requirement), which nudges the model to try harder to produce a valid-looking hash, rather than recognizing it should leave the field null. That's likely why the repair attempt also failed in my case.

Fix: add a description to the expected_sha256 field in schemas.py. Pydantic includes description in model_json_schema() automatically, so this becomes embedded, authoritative guidance the model sees on every turn (not just during repair), without touching the runtime/retry logic that's shared across every agent turn on the system.

Scope: one field, one file, additive only (no behavior change for valid checksums; only guides the model away from inventing invalid ones).

Reproduction: submit any /task-start task using a source_url asset (e.g. a public dataset URL) with no expected_sha256 supplied.