### PR TITLE
Allow cancelling paused research runs

### DIFF
--- a/services/research-orchestrator/app/state_machine.py
+++ b/services/research-orchestrator/app/state_machine.py
@@ -173,9 +173,10 @@ TRANSITIONS: dict[RunState, set[RunState]] = {
         RunState.TIMED_OUT,
     },
     # Pause can happen in any non-terminal phase and resume re-enters the phase
-    # recorded in resume_state, so the graph keeps PAUSED broadly permissive
-    # rather than enumerating one allowed exit per origin state.
-    RunState.PAUSED: set(RunState) - TERMINAL_STATES - {RunState.PAUSED},
+    # recorded in resume_state. Operators must also be able to discard a paused
+    # run without resuming it and accidentally starting another agent turn.
+    RunState.PAUSED: set(RunState)
+    - {RunState.PAUSED, RunState.COMPLETE, RunState.FAILED, RunState.TIMED_OUT},
     # Terminal states have no outgoing edges: once COMPLETE/FAILED/CANCELLED/
     # TIMED_OUT, no further transition can pass validation.
     RunState.COMPLETE: set(),

--- a/services/research-orchestrator/tests/test_state_and_schemas.py
+++ b/services/research-orchestrator/tests/test_state_and_schemas.py
@@ -47,8 +47,11 @@ def test_valid_and_invalid_state_transitions() -> None:
         RunState.BEAKER_PLANNING,
     )
     validate_transition(RunState.BEAKER_PLANNING, RunState.BEAKER_IMPLEMENTING)
+    validate_transition(RunState.PAUSED, RunState.CANCELLED)
     with pytest.raises(InvalidTransition):
         validate_transition(RunState.CREATED, RunState.COMPLETE)
+    with pytest.raises(InvalidTransition):
+        validate_transition(RunState.PAUSED, RunState.COMPLETE)
     with pytest.raises(InvalidTransition):
         validate_transition(RunState.COMPLETE, RunState.PREPARING)
 

--- a/services/research-orchestrator/tests/test_workflow.py
+++ b/services/research-orchestrator/tests/test_workflow.py
@@ -1675,6 +1675,21 @@ def test_cancellation_aborts_sessions_and_jobs(orchestrator_bundle) -> None:
     )
 
 
+def test_cancellation_discards_paused_run_without_resuming(orchestrator_bundle) -> None:
+    _, store, _, runtime, engine = orchestrator_bundle
+    run = engine.create_run(
+        RunCreateRequest(objective='Discard a paused research run.')
+    )
+    engine.pause_run(run.run_id, requested_by='test')
+
+    cancelled = engine.cancel_run(run.run_id, requested_by='test')
+
+    assert cancelled.state == RunState.CANCELLED
+    assert store.get_run(run.run_id).state == RunState.CANCELLED
+    assert runtime.aborted
+    assert store.list_events(run.run_id)[-1].event_type == 'run.cancelled'
+
+
 def test_event_sequence_is_append_only_and_ordered(orchestrator_bundle) -> None:
     _, store, _, _, engine = orchestrator_bundle
     run = engine.create_run(


### PR DESCRIPTION
Fixes the active-run deadlock: a PAUSED run can now transition directly to CANCELLED without resuming and starting another agent turn. Adds state-machine and workflow coverage.