### PR TITLE
Move research orchestrator state to Postgres

### DIFF
--- a/docs/glasslab-v2/image-distribution.md
+++ b/docs/glasslab-v2/image-distribution.md
@@ -57,6 +57,9 @@ The script:
 5. atomically renders each Deployment with the selected image
 6. waits for rollouts
 7. runs workflow-api and orchestrator readiness checks
+8. applies the conservative provisioner-local control-service image tag
+   retention policy after those checks pass (the current and three newest tags
+   per service are retained, along with images used by running containers)
 
 Roll back by selecting a previously published commit:
 
@@ -77,3 +80,21 @@ The local build, push, and containerd-import helpers remain break-glass tools
 for registry outages. They are not the contributor or normal deployment path.
 Node-local imports were useful during bring-up but make scheduling, rollback,
 and provenance depend on hidden machine state.
+
+## Local image retention
+
+`rollout-research-services.sh` calls
+`scripts/prune-control-service-images.sh --apply --retain-tag <deployed-sha>`
+only after a successful rollout and smoke checks. The helper removes old Docker
+*tags* for the two control-service repositories on `.44`; it never runs Docker
+system prune, deletes containers or volumes, or touches unrelated images.
+
+Preview cleanup without changing anything:
+
+```bash
+./scripts/prune-control-service-images.sh
+```
+
+Skip it during investigation with `--skip-image-prune` on the rollout command.
+This policy manages the provisioner's Docker build/pull cache. Kubernetes
+worker-node image eviction remains kubelet/containerd policy.

--- a/docs/research-orchestrator-command-surface.md
+++ b/docs/research-orchestrator-command-surface.md
@@ -20,7 +20,7 @@ and approval role or explicit administrator allowlist.
 | `/research-artifacts [run_id:<id>] [include_source:<bool>]` | Run thread, or main channel with `run_id` | Downloads a digest-verified ZIP of the latest run-level artifacts and successful-job outputs. |
 | `/research-pause [run_id:<id>] [reason:<text>]` | Run thread, or main channel with `run_id` | Aborts an active model turn, preserves state, and records where to resume. |
 | `/research-resume [run_id:<id>] [reason:<text>]` | Run thread, or main channel with `run_id` | Restores a paused run to its prior state and restarts workflow recovery. |
-| `/research-cancel [run_id:<id>] [reason:<text>]` | Run thread, or main channel with `run_id` | Cancels the run, aborts active OpenCode turns, requests cancellation of active jobs, and records the Discord actor and reason. |
+| `/research-cancel [run_id:<id>] [reason:<text>]` | Run thread, or main channel with `run_id` | Cancels the run, aborts active Hermes turns, requests cancellation of active jobs, and records the Discord actor and reason. |
 
 Inside a run thread, pause, resume, and cancel resolve the run from the thread
 and do not require an ID.
@@ -71,7 +71,7 @@ reference in `problem.md` or the objective.
 - If verification finds missing or invalid evidence, a fresh bounded revision
   budget begins and Beaker receives the failure details.
 - `/research-pause` aborts an active model turn but preserves the worktree and
-  recovery checkpoint. `/research-resume` starts a fresh OpenCode session from
+  recovery checkpoint. `/research-resume` starts a fresh Hermes session from
   that checkpoint.
 - `FAILED`, `CANCELLED`, and `TIMED_OUT` are terminal. They cannot currently be
   resumed. Retry-from-terminal-checkpoint is a known missing capability.
@@ -209,7 +209,7 @@ When structural validation is insufficient:
 4. Honeydew reviews the read-only sealed copy.
 5. A human approves promotion into the trusted contract catalog.
 
-Neither OpenCode agent can edit a promoted contract or substitute an evaluator
+Neither Hermes agent can edit a promoted contract or substitute an evaluator
 entry point in a job request.
 
 ## HTTP Operator API
@@ -280,12 +280,12 @@ curl -fsS "http://127.0.0.1:18080/runs/$RUN/artifacts" | jq
 curl -N "http://127.0.0.1:18080/runs/$RUN/events/stream"
 ```
 
-The run's workspaces, protocol, reports, OpenCode data, and recovery checkpoints
+The run's workspaces, protocol, reports, Hermes data, and recovery checkpoints
 are stored beneath
 `/mnt/artifacts/research-orchestrator/runs/<run-id>/` in the orchestrator pod.
 Use `kubectl exec` from the provisioner to inspect them. The HTTP API does not
 yet expose a dedicated full-turn endpoint; normalized events are the stable
-external record, while raw OpenCode storage is an implementation detail.
+external record, while raw runtime storage is an implementation detail.
 
 ## Deployment Commands
 
@@ -318,7 +318,7 @@ runs live readiness checks.
 
 Implemented and live:
 
-- separate Honeydew and Beaker OpenCode sessions and workspaces
+- separate Honeydew and Beaker Hermes sessions and workspaces
 - fresh-session recovery after failed or interrupted agent turns, with compact
   persisted checkpoints and unchanged worktrees
 - a bounded Beaker planning turn before implementation, without a fixed
@@ -339,7 +339,7 @@ Validated:
 - 98 research-orchestrator tests
 - 159 workflow-api tests
 - mocked complete research workflow
-- live OpenCode/Qwen structured task compilation
+- live Hermes/Qwen structured task compilation
 - live Discord threads, identities, approvals, rejection feedback, and
   cancellation projection
 - live Discord registration of dataset upload, pause, and resume commands
@@ -370,7 +370,9 @@ path is `/task-start`, not another hardcoded task entry.
 ## Current Limitations
 
 - one active research run
-- one orchestrator replica and SQLite WAL
+- one orchestrator replica; PostgreSQL is durable, but horizontal scaling is
+  deliberately deferred until active-run and Discord ownership policies are
+  broadened
 - fixed approved repository and runtime profiles
 - no authenticated remote dataset download or private object-store browser
 - no Discord list or status commands

--- a/docs/research-orchestrator-discord-operator-guide.md
+++ b/docs/research-orchestrator-discord-operator-guide.md
@@ -1,0 +1,115 @@
+# Research Orchestrator Discord Guide
+
+Discord is the human control surface for a Glasslab research run. It projects
+the durable PostgreSQL records and append-only event log; it is not agent
+memory, job truth, or the source of authority. Honeydew and Beaker are Hermes
+agents backed by the lab Qwen endpoint. Their raw model tokens and tool traces
+are intentionally not posted to Discord.
+
+Only the configured channel accepts commands. Approval controls require the
+configured administrator role (`Mystic Arts Master`) or an explicitly allowed
+user ID. The role ID, bot token, and operator token are local Kubernetes
+secret data and must not be committed.
+
+## Start A Run
+
+Use the configured Glasslab channel.
+
+```text
+/research-start objective:<research question>
+```
+
+For an arbitrary packaged task, attach a ZIP containing `problem.md` and run:
+
+```text
+/task-start archive:<ZIP> objective:<optional narrower objective>
+```
+
+`/benchmark-start` is a compatibility alias for `/task-start`. New work
+should use `/task-start`.
+
+For local data, upload it before starting the task:
+
+```text
+/dataset-upload dataset:<file> name:<short-name> role:<train|test|reference>
+```
+
+The bot returns an immutable `glasslab-dataset://<sha256>` reference. Put that
+exact reference in `problem.md`; the executor resolves and verifies it from
+read-only shared storage. A task archive is an instruction bundle, not a way
+to sneak unregistered data into a job.
+
+## What Happens Next
+
+1. The bot creates one thread and a live status message for the run.
+2. Honeydew drafts `program.md`: question, hypothesis, controls, metrics,
+   stopping conditions, evidence, and the proposed evaluation contract.
+3. An administrator approves or rejects the protocol in that thread.
+4. Beaker plans and implements the bounded workload, then proposes a normalized
+   experiment matrix. It has no `kubectl`, SSH, secret, push, or registry
+   access.
+5. Honeydew reviews methodology and the immutable evaluation contract.
+6. An administrator approves or rejects the execution request. The approval
+   message states the variants, seeds, job count, resources, required
+   artifacts, contract digest, and what improvement is being tested.
+7. The orchestrator submits the approved matrix through `workflow-api`; the
+   model runtime is idle while Kubernetes jobs run.
+8. Beaker analyzes persisted job logs and artifacts. Honeydew independently
+   verifies claims, writes `report.md`, and asks for final acceptance.
+
+Pressing **Approve** authorizes exactly the stated action. It is not evidence
+that a cluster job, evaluator, or report succeeded.
+
+## Controls
+
+Inside a run thread, commands infer the run ID. From the main channel, supply
+`run_id` when the command offers it.
+
+| Command | Effect |
+| --- | --- |
+| `/research-pause [run_id] [reason]` | Aborts an active Hermes turn, preserves workspaces and recovery state, and records the pause. |
+| `/research-resume [run_id] [reason]` | Restarts workflow recovery from the recorded state. |
+| `/research-cancel [run_id] [reason]` | Cancels the run, aborts active agent work, requests cancellation for active jobs, and records the actor and reason. A paused run may be cancelled. |
+| `/research-artifacts [run_id] [include_source]` | Delivers a digest-verified archive of run artifacts and successful-job outputs. |
+
+Reject buttons collect a reason. The reason becomes durable review feedback for
+the appropriate agent; it must produce a follow-up state or failure message,
+not leave the thread silent.
+
+## Results And Failure
+
+Use `/research-artifacts` from the run thread after jobs complete. The bundle
+contains the protocol, report when available, evaluator output, metrics,
+tables, manifests, logs, and generated analysis notebook when those records
+exist. `artifact-manifest.json` records each delivered file's origin and
+SHA-256 digest. The evaluator output, not the notebook or agent prose, is the
+authoritative scientific evidence.
+
+A failed Kubernetes job is normally an observation routed back to Beaker. A
+bad preflight is rejected before submission. Terminal `FAILED`, `CANCELLED`,
+and `TIMED_OUT` runs cannot yet be cloned or retried from Discord; start a new
+bounded run after reviewing the evidence.
+
+## Inspecting Without Discord
+
+The service is internal-only. From a contributor workstation, tunnel through
+the provisioner:
+
+```bash
+ssh -L 18080:127.0.0.1:18080 glasslab-provisioner \
+  'sudo -n env KUBECONFIG=/home/glasslab/.kube/config kubectl -n glasslab-v2 \
+   port-forward svc/glasslab-research-orchestrator 18080:8080'
+```
+
+Then inspect persisted state:
+
+```bash
+curl -fsS http://127.0.0.1:18080/runs | jq
+curl -fsS http://127.0.0.1:18080/runs/<run-id>/events | jq
+curl -fsS http://127.0.0.1:18080/runs/<run-id>/artifacts | jq
+```
+
+Do not place credentials in commands, shell history, screenshots, Discord, or
+Git. For implementation boundaries and recovery details, see
+[`research-orchestrator.md`](research-orchestrator.md) and the concise
+[`research-orchestrator-command-surface.md`](research-orchestrator-command-surface.md).

--- a/docs/research-orchestrator.md
+++ b/docs/research-orchestrator.md
@@ -1,12 +1,12 @@
 # Glasslab Research Orchestrator
 
 Status: deployed as a single-replica MVP. The complete workflow is covered with
-mocked OpenCode and cluster adapters. OpenCode against the two-node exo model,
+mocked Hermes and cluster adapters. Hermes against the two-node exo model,
 Discord threads and role-gated controls, restart recovery, and live Kubernetes
 deployment were tested on 2026-07-29. Three imported ML benchmark task types
 now have bounded CPU/GPU workload definitions and immutable evaluator contracts;
 their live end-to-end execution status is recorded below. Generic TaskSpec
-compilation and preflight were validated against live OpenCode and Qwen with a
+compilation and preflight were validated against the live agent runtime and Qwen with a
 synthetic task; a complete arbitrary-dataset run remains outstanding.
 
 For the concise operator surface, read
@@ -28,7 +28,7 @@ existing bounded execution plane:
       |             |
       v             v
  Honeydew        Beaker
- OpenCode        OpenCode
+ Hermes          Hermes
  runtime         runtime
       |             |
       +------+------+
@@ -46,7 +46,7 @@ existing bounded execution plane:
   artifacts + evaluation output
 ```
 
-OpenCode is the inner runtime. It performs each agent's model call, local tool
+Hermes is the inner runtime. It performs each agent's model call, local tool
 loop, file changes, and structured response. The orchestrator is the outer
 scientific workflow. It owns turn-taking, approvals, durable state, privileged
 actions, evidence, interruption, and recovery.
@@ -111,20 +111,20 @@ Beaker for analysis. It does not automatically fail the research run.
 
 ## Durable Records
 
-The service stores runs, turns, actions, jobs, artifacts, and append-only events
-in SQLite with WAL enabled. Each event receives a monotonically increasing
-per-run sequence inside the same transaction as its state change.
+The production service stores runs, turns, actions, jobs, artifacts, knowledge
+records, and append-only events in PostgreSQL. Records are JSONB with typed
+query columns; each event receives a monotonically increasing per-run sequence
+inside the same transaction as its state change. A transaction-scoped advisory
+lock makes the one-active-run policy and event ordering correct across process
+boundaries. SQLite with WAL remains the local-development and smoke-test
+backend, plus a one-time import source for the previous deployment.
 
-The deployment is deliberately fixed at one replica. SQLite is placed on the
-shared artifacts PVC. PostgreSQL is the expected next storage step before
-horizontal scaling.
-
-Normalized event names form the stable external contract. Raw OpenCode event
+Normalized event names form the stable external contract. Raw runtime event
 names are translated into events such as `agent.tool_started`,
 `agent.turn_completed`, `action.proposed`, `job.completed`, and
 `artifact.recorded`.
 
-## Workspaces And OpenCode
+## Workspaces And Hermes
 
 Each run has this layout:
 
@@ -147,15 +147,12 @@ The snapshot rejects symlinks and path escapes, enforces file and byte limits,
 records SHA-256 digests, and is read-only. Honeydew therefore reviews Beaker's
 actual candidate without gaining write access to Beaker's worktree.
 
-The OpenCode adapter starts one authenticated `opencode serve` child process
-per agent. Each process receives a separate workspace, XDG configuration and
-data directory, system prompt, permission configuration, server port, and
-session ID. Sessions are recorded in the database and reconnected after an
-orchestrator restart. Active turns have an explicit abort path.
-
-The adapter uses the installed OpenCode HTTP API for server health, session
-creation, structured message output, event streaming, and abort. Runtime event
-names are not persisted directly.
+The Hermes adapter starts one isolated Hermes process per agent. Each process
+receives a separate workspace, configuration/data directory, system prompt,
+permission configuration, server port, and session ID. Sessions are recorded
+in the database and reconstructed after an orchestrator restart. Active turns
+have an explicit abort path. Runtime event names are normalized before they are
+persisted.
 
 The current deployment configuration points both runtimes at:
 
@@ -242,8 +239,9 @@ evidence URI of the form `knowledge://<source_id>`. Re-ingesting identical
 content from the same canonical URI deduplicates to the original source row so
 its evidence URI stays stable; sources are invalidated explicitly by digest.
 
-Retrieval is lexical and quality-ranked. It uses SQLite FTS5 with BM25 ranking,
-weighted by exact query-term overlap. The final ranking preserves the anchor
+Retrieval is lexical and quality-ranked. The production backend uses PostgreSQL
+full-text ranking; SQLite FTS5 remains the local fallback. Ranking is weighted
+by exact query-term overlap. The final ranking preserves the anchor
 behavior of lexical exact-match for distinct-topic queries so a
 distinct-topic result cannot be displaced by a generic near-match. Embedding-
 based semantic similarity and reranking are planned but not yet implemented.
@@ -267,7 +265,7 @@ exact context packet that grounded a claim; a claim about knowledge requires a
 
 The generic contribution path accepts a ZIP with exactly one `problem.md` and
 zero or one `eval_agent_prompt.md`; its filename has no semantic meaning.
-Honeydew reads the normalized files in a temporary isolated OpenCode session
+Honeydew reads the normalized files in a temporary isolated Hermes session
 and returns a validated `glasslab-task-spec-v1` containing:
 
 - a human-facing name
@@ -285,7 +283,7 @@ repository-controlled `generic-task-integrity-v1` contract.
 
 Local datasets are ingested separately from task ZIPs. The HTTP and Discord
 surfaces accept a bounded file, store it read-only under the shared artifact
-mount, and register its SHA-256 digest in SQLite. The returned
+mount, and register its SHA-256 digest in the durable store. The returned
 `glasslab-dataset://<sha256>` reference is the model-facing identifier. Task
 compilation resolves it to an `s3://artifacts/...` contract; preflight verifies
 the file and digest, and `workflow-api` mounts the exact PVC subpath read-only
@@ -411,7 +409,7 @@ gap.
 
 ## Long Jobs And Recovery
 
-Agent turns end before submission. While jobs run, OpenCode is idle and the
+Agent turns end before submission. While jobs run, Hermes is idle and the
 watcher reconciles authoritative job state. Completion records exit details and
 artifacts before beginning a new agent turn.
 
@@ -424,14 +422,14 @@ At startup the service:
 4. reconciles `JOB_QUEUED` and `JOB_RUNNING` jobs, and
 5. advances workflows only after authoritative evidence is stored.
 
-Cancellation aborts active OpenCode turns and requests cancellation for every
+Cancellation aborts active Hermes turns and requests cancellation for every
 nonterminal job. Prior events are retained.
 
 Pause records the exact state to resume. If recovery after resume fails, the
-orchestrator records the failed turn, terminates that agent's OpenCode process,
+orchestrator records the failed turn, terminates that agent's Hermes process,
 clears the stale session ID, writes
 `events/<agent>-recovery-checkpoint.json`, and returns the run to `PAUSED`.
-Resume creates a fresh OpenCode session, injects the compact checkpoint, and
+Resume creates a fresh Hermes session, injects the compact checkpoint, and
 continues from the unchanged worktree. Successful sessions remain reusable
 across normal turns. Resume also detects older paused records whose latest
 failed turn still references the attached session and rotates them before
@@ -588,7 +586,7 @@ Cancel an active run from its Discord thread:
 ```
 
 From the configured main channel, provide `run_id`. Cancellation aborts active
-OpenCode turns, requests cancellation of active cluster jobs, records the
+Hermes turns, requests cancellation of active cluster jobs, records the
 administrator identity and reason, and publishes the durable cancellation
 event back to the run thread.
 
@@ -625,7 +623,7 @@ are under `kubeadm/glasslab-v2/research-orchestrator` and are included by
 `scripts/deploy-glasslab-v2.sh`.
 
 The manifest enforces one replica, disables service-account token mounting,
-runs as a non-root user, and stores SQLite and workspaces on
+runs as a non-root user, and stores workspaces on
 `glasslab-shared-artifacts`. An init container maintains the approved
 repository checkout.
 
@@ -645,7 +643,7 @@ Before deployment:
 The Titanic agent stack remains under `services/agent-api`, `services/runner`,
 and `kubeadm/agent-stack`. It is preserved as v1 reference material.
 
-The orchestrator does not copy its Titanic-specific intent parser, SQLite
+The orchestrator does not copy its Titanic-specific intent parser, legacy SQLite
 schema, or direct Kubernetes submission model. It reuses the lessons and the
 bounded execution boundary represented by `workflow-api` and
 `research-workspace-runner`. The old stack can continue to run during migration.
@@ -655,7 +653,7 @@ bounded execution boundary represented by `workflow-api` and
 Implemented:
 
 - state machine, durable records, ordered events, approvals, and recovery
-- isolated worktree and OpenCode runtime adapters
+- isolated worktree and Hermes runtime adapters
 - structured turn validation and normalized runtime events
 - contract digest checks and read-only job rendering
 - policy, quotas, matrix expansion, fake and workflow-api cluster adapters
@@ -669,17 +667,17 @@ Implemented:
 Covered by mocks:
 
 - the full Honeydew/Beaker workflow
-- structured OpenCode turn completion and abort behavior
+- structured Hermes turn completion and abort behavior
 - parallel fake jobs, completion, failure evidence, and artifacts
 - restart reconciliation and cancellation
 - knowledge ingestion, retrieval scoping, and context attachment
 
 Manually tested:
 
-- OpenCode `1.4.6` headless health and session create/delete on this laptop
-- the non-root service image build, OpenCode version, application import, and
+- Hermes runtime health and structured turn completion against Qwen
+- the non-root service image build, Hermes version, application import, and
   `/ready` response
-- a real structured Honeydew turn through OpenCode `1.4.6` and the exo-served
+- a real structured Honeydew turn through Hermes and the exo-served
   `mlx-community/Qwen3-Coder-Next-4bit` model from `.44`
 - live Discord public-thread creation, editable status publication, and
   Honeydew/Beaker webhook identities in the configured guild and channel
@@ -701,7 +699,7 @@ Not yet tested:
 ## MVP Limitations
 
 - one orchestrator replica and one active research run
-- SQLite WAL rather than PostgreSQL
+- PostgreSQL live migration and recovery against the cluster database
 - one approved repository and fixed agent profiles
 - one process per agent, not a separate pod or Unix identity
 - no Git push, PR creation, arbitrary SSH, or raw Kubernetes access

--- a/kubeadm/glasslab-v2/research-orchestrator/10-configmap.yaml
+++ b/kubeadm/glasslab-v2/research-orchestrator/10-configmap.yaml
@@ -4,6 +4,9 @@ metadata:
   name: glasslab-research-orchestrator-config
   namespace: glasslab-v2
 data:
+  # The record/event store is Postgres. SQLite is retained only as an import
+  # source and local-development fallback.
+  GLASSLAB_ORCHESTRATOR_STORE_BACKEND: postgres
   GLASSLAB_ORCHESTRATOR_DATABASE_PATH: /mnt/artifacts/research-orchestrator/state/orchestrator.db
   GLASSLAB_ORCHESTRATOR_WORKSPACE_ROOT: /mnt/artifacts/research-orchestrator/runs
   GLASSLAB_ORCHESTRATOR_ARTIFACT_ROOT: /mnt/artifacts/research-orchestrator/artifacts

--- a/kubeadm/glasslab-v2/research-orchestrator/11-secret.example.yaml
+++ b/kubeadm/glasslab-v2/research-orchestrator/11-secret.example.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: glasslab-v2
 type: Opaque
 stringData:
+  GLASSLAB_ORCHESTRATOR_STORE_POSTGRES_DSN: postgresql://glasslab:change-me-before-deploy@glasslab-postgres.glasslab-v2.svc.cluster.local:5432/glasslab
   GLASSLAB_ORCHESTRATOR_OPERATOR_API_TOKEN: generate-a-long-random-token
   GLASSLAB_ORCHESTRATOR_DISCORD_BOT_TOKEN: change-me
   GLASSLAB_ORCHESTRATOR_DISCORD_WEBHOOK_URL: change-me

--- a/kubeadm/glasslab-v2/research-orchestrator/20-deployment.yaml
+++ b/kubeadm/glasslab-v2/research-orchestrator/20-deployment.yaml
@@ -5,10 +5,8 @@ metadata:
   namespace: glasslab-v2
 spec:
   replicas: 1
-  # SQLite WAL supports one orchestrator process. Do not overlap old and new
-  # pods during an update until the service moves to PostgreSQL.
   strategy:
-    type: Recreate
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: glasslab-research-orchestrator
@@ -63,6 +61,12 @@ spec:
             - secretRef:
                 name: glasslab-research-orchestrator
                 optional: true
+          env:
+            - name: GLASSLAB_ORCHESTRATOR_STORE_POSTGRES_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: glasslab-research-orchestrator
+                  key: GLASSLAB_ORCHESTRATOR_STORE_POSTGRES_DSN
           ports:
             - containerPort: 8080
               name: http

--- a/scripts/prune-control-service-images.sh
+++ b/scripts/prune-control-service-images.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Remove only old local tags for the two CI-published control services. This
+# never prunes containers, volumes, build cache, or unrelated images.
+KEEP=3
+APPLY=false
+RETAIN_TAGS=()
+REPOSITORIES=(
+  'ghcr.io/offensivegeneric/glasslab-workflow-api'
+  'ghcr.io/offensivegeneric/glasslab-research-orchestrator'
+)
+
+usage() {
+  cat <<'USAGE'
+Usage: prune-control-service-images.sh [--apply] [--keep N] [--retain-tag TAG]
+
+Lists old local GHCR control-service image tags by default. --apply removes
+only tags outside the retention window. Running-container image IDs and tags
+named with --retain-tag are always preserved. This is a provisioner Docker
+cache policy; worker-node image GC remains kubelet-managed.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) APPLY=true; shift ;;
+    --keep) KEEP="${2:?missing value}"; shift 2 ;;
+    --retain-tag) RETAIN_TAGS+=("${2:?missing value}"); shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'unknown argument: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[[ "$KEEP" =~ ^[1-9][0-9]*$ ]] || { printf '%s\n' '--keep must be a positive integer' >&2; exit 2; }
+command -v docker >/dev/null || { printf '%s\n' 'docker is required' >&2; exit 1; }
+
+mapfile -t RUNNING_IDS < <(docker ps --format '{{.ImageID}}' | sort -u)
+is_running_id() { local id="$1"; local item; for item in "${RUNNING_IDS[@]}"; do [[ "$item" == "$id" ]] && return 0; done; return 1; }
+is_retained_tag() { local tag="$1"; local item; for item in "${RETAIN_TAGS[@]}"; do [[ "$item" == "$tag" ]] && return 0; done; return 1; }
+
+removed=0
+for repository in "${REPOSITORIES[@]}"; do
+  # CreatedAt is formatted ISO-like by Docker and sorted newest first. <none>
+  # tags are deliberately ignored: removing a dangling layer is not this tool's
+  # job and can affect unrelated builds.
+  mapfile -t rows < <(docker image ls "$repository" --format '{{.CreatedAt}}|{{.Tag}}|{{.ID}}' | sort -r)
+  kept=0
+  for row in "${rows[@]}"; do
+    IFS='|' read -r _created tag image_id <<<"$row"
+    [[ "$tag" == '<none>' ]] && continue
+    if is_running_id "$image_id" || is_retained_tag "$tag" || (( kept < KEEP )); then
+      ((kept+=1))
+      continue
+    fi
+    ref="$repository:$tag"
+    if [[ "$APPLY" == true ]]; then
+      printf '[image-retention] removing old tag %s\n' "$ref"
+      docker image rm "$ref"
+    else
+      printf '[image-retention] would remove %s (dry run)\n' "$ref"
+    fi
+    ((removed+=1))
+  done
+done
+printf '[image-retention] %s %d old control-service tag(s)\n' "$([[ "$APPLY" == true ]] && echo removed || echo identified)" "$removed"

--- a/scripts/rollout-research-services.sh
+++ b/scripts/rollout-research-services.sh
@@ -8,6 +8,7 @@ SERVICE="all"
 IMAGE_TAG=""
 SYNC=false
 SKIP_SMOKE=false
+SKIP_IMAGE_PRUNE=false
 
 usage() {
   cat <<'USAGE'
@@ -21,6 +22,7 @@ Options:
   --tag <tag>       GHCR image tag. Default: full SHA of the checked-out commit
   --sync            Fast-forward the canonical checkout to origin/main first
   --skip-smoke      Skip post-rollout service health checks
+  --skip-image-prune  Do not apply the local control-service tag retention policy
   -h, --help        Show this help
 USAGE
 }
@@ -103,6 +105,10 @@ while [[ $# -gt 0 ]]; do
       SKIP_SMOKE=true
       shift
       ;;
+    --skip-image-prune)
+      SKIP_IMAGE_PRUNE=true
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -175,6 +181,11 @@ if [[ "$SKIP_SMOKE" != true ]]; then
   "$KUBECTL" -n "$NAMESPACE" exec \
     deployment/glasslab-research-orchestrator -c orchestrator -- \
     python -c 'import json, urllib.request; print(json.load(urllib.request.urlopen("http://127.0.0.1:8080/ready")))'
+fi
+
+if [[ "$SKIP_IMAGE_PRUNE" != true ]]; then
+  "$ROOT_DIR/scripts/prune-control-service-images.sh" --apply \
+    --retain-tag "$IMAGE_TAG"
 fi
 
 printf '[rollout-research-services] done\n'

--- a/services/research-orchestrator/.env.example
+++ b/services/research-orchestrator/.env.example
@@ -1,3 +1,7 @@
+# SQLite is the local-development default. The live deployment sets postgres
+# and reads the DSN from its Kubernetes Secret.
+GLASSLAB_ORCHESTRATOR_STORE_BACKEND=sqlite
+GLASSLAB_ORCHESTRATOR_STORE_POSTGRES_DSN=
 GLASSLAB_ORCHESTRATOR_DATABASE_PATH=/var/lib/glasslab-research-orchestrator/orchestrator.db
 GLASSLAB_ORCHESTRATOR_WORKSPACE_ROOT=/var/lib/glasslab-research-orchestrator/runs
 GLASSLAB_ORCHESTRATOR_ARTIFACT_ROOT=/mnt/artifacts/research-orchestrator

--- a/services/research-orchestrator/app/config.py
+++ b/services/research-orchestrator/app/config.py
@@ -29,6 +29,8 @@ class Settings(BaseSettings):
 
     app_name: str = 'glasslab-research-orchestrator'
     app_version: str = '0.1.0'
+    store_backend: Literal['sqlite', 'postgres'] = 'sqlite'
+    store_postgres_dsn: str | None = None
     database_path: str = '/tmp/glasslab-research-orchestrator/orchestrator.db'
     workspace_root: str = '/tmp/glasslab-research-orchestrator/runs'
     artifact_root: str = '/tmp/glasslab-research-orchestrator/artifacts'
@@ -140,6 +142,13 @@ class Settings(BaseSettings):
     @property
     def effective_agent_model_name(self) -> str:
         return self.agent_model_name or self.qwen_model_name
+
+    @field_validator('store_postgres_dsn')
+    @classmethod
+    def require_postgres_dsn(cls, value: str | None, info) -> str | None:
+        if info.data.get('store_backend') == 'postgres' and not (value or '').strip():
+            raise ValueError('postgres store backend requires a non-empty store_postgres_dsn')
+        return value
 
     @field_validator('permitted_job_images', mode='before')
     @classmethod

--- a/services/research-orchestrator/app/main.py
+++ b/services/research-orchestrator/app/main.py
@@ -59,6 +59,7 @@ from .schemas import (
     SourceType,
 )
 from .storage import ConcurrencyConflict, RecordNotFound, SqliteStore
+from .postgres_store import PostgresStore
 from .task_bundles import (
     TaskBundleError,
     TaskBundleManager,
@@ -85,7 +86,11 @@ def build_engine(
     # Composition root: wires every subsystem against the same store so all
     # mutations share one transaction boundary and one event log. The cluster
     # executor is swapped for a fake when running without a live API.
-    store = SqliteStore(settings.database_path)
+    store = (
+        PostgresStore(settings.store_postgres_dsn)
+        if settings.store_backend == 'postgres'
+        else SqliteStore(settings.database_path)
+    )
     if runtime is None:
         runtime = build_agent_runtime(settings)
     if cluster is None:

--- a/services/research-orchestrator/app/postgres_store.py
+++ b/services/research-orchestrator/app/postgres_store.py
@@ -1,0 +1,325 @@
+"""PostgreSQL durable store for the research orchestrator.
+
+SQLite remains useful for isolated tests and the local smoke path.  This store
+is the production counterpart: record payloads are JSONB while query and
+integrity fields are relational columns.  A transaction-scoped advisory lock
+serializes the small control plane's compound mutations (active-run checks and
+per-run event sequence allocation) across replicas without relying on process
+local locks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from contextlib import contextmanager
+from datetime import datetime
+import json
+from types import ModuleType
+from typing import Any, Iterator
+
+from .schemas import (
+    ActionRecord, AgentName, ApprovalStatus, ArtifactRecord, ContextPacket,
+    EventRecord, IngestedDatasetRecord, JobRecord, JobStatus, KnowledgeChunk,
+    KnowledgeSource, RunRecord, RunState, SourceType, TERMINAL_STATES,
+    TurnKind, TurnRecord, utc_now,
+)
+from .state_machine import HUMAN_WAIT_STATES, validate_transition
+from .storage import ConcurrencyConflict, RecordNotFound
+
+
+def _import_psycopg() -> ModuleType:
+    # Keep SQLite-only tests and local smoke runs importable without the
+    # optional Postgres wheel. Production fails at construction, not later.
+    import psycopg
+
+    return psycopg
+
+
+class PostgresStore:
+    """Transactional PostgreSQL store with the SqliteStore public surface."""
+
+    def __init__(self, dsn: str | None) -> None:
+        if not (dsn or '').strip():
+            raise ValueError('postgres store requires a non-empty dsn')
+        self._dsn = str(dsn)
+        self._psycopg = _import_psycopg()
+        self._ensure_schema()
+
+    def _connect(self):
+        from psycopg.rows import dict_row
+
+        return self._psycopg.connect(self._dsn, row_factory=dict_row)
+
+    @staticmethod
+    def _payload(record: Any):
+        from psycopg.types.json import Jsonb
+
+        return Jsonb(record.model_dump(mode='json'))
+
+    @contextmanager
+    def transaction(self) -> Iterator[Any]:
+        with self._connect() as conn:
+            with conn.transaction():
+                # A short control-plane lock is intentional. It makes the
+                # one-active-run policy and per-run event sequences correct
+                # across replicas; jobs/model turns remain outside it.
+                conn.execute('SELECT pg_advisory_xact_lock(734882001)')
+                yield conn
+
+    def _ensure_schema(self) -> None:
+        statements = '''
+        CREATE TABLE IF NOT EXISTS orchestrator_runs (
+          run_id TEXT PRIMARY KEY, state TEXT NOT NULL, version INTEGER NOT NULL,
+          payload JSONB NOT NULL, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL);
+        CREATE INDEX IF NOT EXISTS orchestrator_runs_state_idx ON orchestrator_runs(state);
+        CREATE TABLE IF NOT EXISTS orchestrator_turns (
+          turn_id TEXT PRIMARY KEY, run_id TEXT NOT NULL REFERENCES orchestrator_runs(run_id),
+          status TEXT NOT NULL, payload JSONB NOT NULL, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL);
+        CREATE INDEX IF NOT EXISTS orchestrator_turns_run_idx ON orchestrator_turns(run_id, created_at);
+        CREATE TABLE IF NOT EXISTS orchestrator_actions (
+          action_id TEXT PRIMARY KEY, run_id TEXT NOT NULL REFERENCES orchestrator_runs(run_id),
+          approval_status TEXT NOT NULL, idempotency_key TEXT NOT NULL UNIQUE,
+          payload JSONB NOT NULL, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL);
+        CREATE INDEX IF NOT EXISTS orchestrator_actions_run_idx ON orchestrator_actions(run_id, created_at);
+        CREATE TABLE IF NOT EXISTS orchestrator_jobs (
+          job_id TEXT PRIMARY KEY, run_id TEXT NOT NULL REFERENCES orchestrator_runs(run_id),
+          action_id TEXT NOT NULL REFERENCES orchestrator_actions(action_id), status TEXT NOT NULL,
+          idempotency_key TEXT NOT NULL UNIQUE, payload JSONB NOT NULL,
+          created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL);
+        CREATE INDEX IF NOT EXISTS orchestrator_jobs_run_idx ON orchestrator_jobs(run_id, created_at);
+        CREATE TABLE IF NOT EXISTS orchestrator_artifacts (
+          artifact_id TEXT PRIMARY KEY, run_id TEXT NOT NULL REFERENCES orchestrator_runs(run_id), job_id TEXT,
+          payload JSONB NOT NULL, created_at TIMESTAMPTZ NOT NULL);
+        CREATE INDEX IF NOT EXISTS orchestrator_artifacts_run_idx ON orchestrator_artifacts(run_id, created_at);
+        CREATE TABLE IF NOT EXISTS orchestrator_datasets (
+          dataset_id TEXT PRIMARY KEY, payload JSONB NOT NULL, created_at TIMESTAMPTZ NOT NULL);
+        CREATE TABLE IF NOT EXISTS orchestrator_events (
+          event_id TEXT PRIMARY KEY, run_id TEXT NOT NULL REFERENCES orchestrator_runs(run_id),
+          sequence_number INTEGER NOT NULL, source TEXT NOT NULL, event_type TEXT NOT NULL,
+          payload JSONB NOT NULL, timestamp TIMESTAMPTZ NOT NULL, UNIQUE(run_id, sequence_number));
+        CREATE INDEX IF NOT EXISTS orchestrator_events_run_idx ON orchestrator_events(run_id, sequence_number);
+        CREATE TABLE IF NOT EXISTS orchestrator_knowledge_sources (
+          source_id TEXT PRIMARY KEY, source_type TEXT NOT NULL, canonical_uri TEXT NOT NULL,
+          run_scope TEXT, digest TEXT NOT NULL, payload JSONB NOT NULL, ingested_at TIMESTAMPTZ NOT NULL,
+          UNIQUE(digest, canonical_uri));
+        CREATE INDEX IF NOT EXISTS orchestrator_knowledge_sources_scope_idx ON orchestrator_knowledge_sources(run_scope);
+        CREATE TABLE IF NOT EXISTS orchestrator_knowledge_chunks (
+          chunk_id TEXT PRIMARY KEY, source_id TEXT NOT NULL REFERENCES orchestrator_knowledge_sources(source_id) ON DELETE CASCADE,
+          chunk_index INTEGER NOT NULL, text TEXT NOT NULL, payload JSONB NOT NULL);
+        CREATE INDEX IF NOT EXISTS orchestrator_knowledge_chunks_source_idx ON orchestrator_knowledge_chunks(source_id, chunk_index);
+        CREATE INDEX IF NOT EXISTS orchestrator_knowledge_chunks_fts_idx ON orchestrator_knowledge_chunks USING GIN (to_tsvector('simple', text));
+        CREATE TABLE IF NOT EXISTS orchestrator_context_packets (
+          packet_id TEXT PRIMARY KEY, run_id TEXT NOT NULL REFERENCES orchestrator_runs(run_id),
+          payload JSONB NOT NULL, created_at TIMESTAMPTZ NOT NULL);
+        CREATE INDEX IF NOT EXISTS orchestrator_context_packets_run_idx ON orchestrator_context_packets(run_id, created_at);
+        '''
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                for statement in statements.split(';'):
+                    if statement.strip():
+                        cur.execute(statement)
+            conn.commit()
+
+    def ping(self) -> bool:
+        with self._connect() as conn:
+            return conn.execute('SELECT 1 AS value').fetchone()['value'] == 1
+
+    def _append_event_conn(self, conn: Any, *, run_id: str, source: str, event_type: str, payload: dict[str, Any]) -> EventRecord:
+        row = conn.execute('SELECT COALESCE(MAX(sequence_number), 0) + 1 AS sequence_number FROM orchestrator_events WHERE run_id = %s', (run_id,)).fetchone()
+        event = EventRecord(sequence_number=int(row['sequence_number']), run_id=run_id, source=source, event_type=event_type, payload=payload)
+        conn.execute('INSERT INTO orchestrator_events (event_id, run_id, sequence_number, source, event_type, payload, timestamp) VALUES (%s, %s, %s, %s, %s, %s, %s)', (event.event_id, event.run_id, event.sequence_number, event.source, event.event_type, self._payload(event), event.timestamp))
+        return event
+
+    def append_event(self, *, run_id: str, source: str, event_type: str, payload: dict[str, Any] | None = None) -> EventRecord:
+        with self.transaction() as conn:
+            return self._append_event_conn(conn, run_id=run_id, source=source, event_type=event_type, payload=payload or {})
+
+    def create_run(self, record: RunRecord, *, one_active_run: bool) -> RunRecord:
+        with self.transaction() as conn:
+            if one_active_run:
+                states = [state.value for state in TERMINAL_STATES]
+                active = conn.execute('SELECT run_id FROM orchestrator_runs WHERE state <> ALL(%s) LIMIT 1', (states,)).fetchone()
+                if active:
+                    raise ConcurrencyConflict(f"active run already exists: {active['run_id']}")
+            conn.execute('INSERT INTO orchestrator_runs (run_id, state, version, payload, created_at, updated_at) VALUES (%s, %s, %s, %s, %s, %s)', (record.run_id, record.state.value, record.version, self._payload(record), record.created_at, record.updated_at))
+            self._append_event_conn(conn, run_id=record.run_id, source='orchestrator', event_type='run.created', payload={'objective': record.objective, 'state': record.state.value})
+        return record
+
+    def _run(self, row: dict[str, Any] | None, run_id: str) -> RunRecord:
+        if row is None: raise RecordNotFound(run_id)
+        return RunRecord.model_validate(row['payload'])
+
+    def get_run(self, run_id: str) -> RunRecord:
+        with self._connect() as conn: return self._run(conn.execute('SELECT payload FROM orchestrator_runs WHERE run_id=%s', (run_id,)).fetchone(), run_id)
+
+    def list_runs(self) -> list[RunRecord]:
+        with self._connect() as conn: return [RunRecord.model_validate(r['payload']) for r in conn.execute('SELECT payload FROM orchestrator_runs ORDER BY created_at DESC').fetchall()]
+
+    def list_active_runs(self) -> list[RunRecord]:
+        with self._connect() as conn:
+            return [RunRecord.model_validate(r['payload']) for r in conn.execute('SELECT payload FROM orchestrator_runs WHERE state <> ALL(%s) ORDER BY created_at', ([s.value for s in TERMINAL_STATES],)).fetchall()]
+
+    def _write_run(self, conn: Any, current: RunRecord, updated: RunRecord, expected_version: int) -> None:
+        result = conn.execute('UPDATE orchestrator_runs SET state=%s, version=%s, payload=%s, updated_at=%s WHERE run_id=%s AND version=%s', (updated.state.value, updated.version, self._payload(updated), updated.updated_at, updated.run_id, expected_version))
+        if result.rowcount != 1: raise ConcurrencyConflict(f'run was updated concurrently: {updated.run_id}')
+
+    def replace_run(self, record: RunRecord, *, expected_version: int) -> RunRecord:
+        updated = record.model_copy(update={'version': expected_version + 1, 'updated_at': utc_now()})
+        with self.transaction() as conn: self._write_run(conn, record, updated, expected_version)
+        return updated
+
+    def reset_methodology_revision_budget(self, run_id: str, *, reason: str) -> RunRecord:
+        with self.transaction() as conn:
+            row = conn.execute('SELECT payload, version FROM orchestrator_runs WHERE run_id=%s FOR UPDATE', (run_id,)).fetchone(); current = self._run(row, run_id)
+            updated = current.model_copy(update={'methodology_revision_count': 0, 'version': int(row['version']) + 1, 'updated_at': utc_now()})
+            self._write_run(conn, current, updated, int(row['version']))
+            self._append_event_conn(conn, run_id=run_id, source='orchestrator', event_type='methodology.revision_budget_reset', payload={'previous_revision_count': current.methodology_revision_count, 'revision_count': 0, 'reason': reason})
+        return updated
+
+    def transition_run(self, run_id: str, target: RunState, *, source: str = 'orchestrator', payload: dict[str, Any] | None = None, updates: dict[str, Any] | None = None) -> RunRecord:
+        with self.transaction() as conn:
+            row = conn.execute('SELECT payload, version FROM orchestrator_runs WHERE run_id=%s FOR UPDATE', (run_id,)).fetchone(); current = self._run(row, run_id); validate_transition(current.state, target); now = utc_now()
+            runtime_updates: dict[str, Any] = {}
+            if target in HUMAN_WAIT_STATES and current.state not in HUMAN_WAIT_STATES:
+                runtime_updates = {'active_runtime_seconds': current.active_runtime_seconds + (max(0.0, (now - current.active_since).total_seconds()) if current.active_since else 0.0), 'active_since': None}
+            elif current.state in HUMAN_WAIT_STATES and target not in HUMAN_WAIT_STATES and target not in TERMINAL_STATES and target != RunState.PAUSED:
+                runtime_updates = {'active_since': now}
+            updated = current.model_copy(update={**(updates or {}), **runtime_updates, 'state': target, 'version': int(row['version']) + 1, 'updated_at': now})
+            self._write_run(conn, current, updated, int(row['version']))
+            self._append_event_conn(conn, run_id=run_id, source=source, event_type='run.state_changed', payload={'from': current.state.value, 'to': target.value, **(payload or {})})
+        return updated
+
+    def _save_payload(self, table: str, id_column: str, record: Any, *, columns: dict[str, Any], conflict: str = 'update') -> Any:
+        keys = [id_column, *columns.keys(), 'payload']; values = [getattr(record, id_column), *columns.values(), self._payload(record)]
+        assignments = ', '.join(f'{key}=EXCLUDED.{key}' for key in keys[1:])
+        with self.transaction() as conn:
+            if conflict == 'return_existing':
+                row = conn.execute(f'SELECT payload FROM {table} WHERE idempotency_key=%s', (columns['idempotency_key'],)).fetchone()
+                if row: return type(record).model_validate(row['payload'])
+            conn.execute(f'INSERT INTO {table} ({", ".join(keys)}) VALUES ({", ".join(["%s"] * len(keys))}) ON CONFLICT ({id_column}) DO UPDATE SET {assignments}', values)
+        return record
+
+    def save_turn(self, record: TurnRecord) -> TurnRecord:
+        return self._save_payload('orchestrator_turns', 'turn_id', record, columns={'run_id': record.run_id, 'status': record.status, 'created_at': record.created_at, 'updated_at': record.updated_at})
+    def list_turns(self, run_id: str) -> list[TurnRecord]:
+        with self._connect() as conn: return [TurnRecord.model_validate(r['payload']) for r in conn.execute('SELECT payload FROM orchestrator_turns WHERE run_id=%s ORDER BY created_at', (run_id,)).fetchall()]
+    def mark_running_turns_interrupted(self, run_id: str) -> int:
+        changed = 0
+        for turn in self.list_turns(run_id):
+            if turn.status == 'running': self.save_turn(turn.model_copy(update={'status': 'failed', 'error': 'orchestrator restarted during active agent turn', 'updated_at': utc_now()})); changed += 1
+        return changed
+
+    def save_action(self, record: ActionRecord) -> ActionRecord:
+        return self._save_payload('orchestrator_actions', 'action_id', record, columns={'run_id': record.run_id, 'approval_status': record.approval_status.value, 'idempotency_key': record.idempotency_key, 'created_at': record.created_at, 'updated_at': record.updated_at}, conflict='return_existing')
+    def get_action(self, action_id: str) -> ActionRecord:
+        with self._connect() as conn:
+            row = conn.execute('SELECT payload FROM orchestrator_actions WHERE action_id=%s', (action_id,)).fetchone()
+        if not row: raise RecordNotFound(action_id)
+        return ActionRecord.model_validate(row['payload'])
+    def list_actions(self, run_id: str) -> list[ActionRecord]:
+        with self._connect() as conn: return [ActionRecord.model_validate(r['payload']) for r in conn.execute('SELECT payload FROM orchestrator_actions WHERE run_id=%s ORDER BY created_at', (run_id,)).fetchall()]
+    def update_action(self, action_id: str, *, approval_status: ApprovalStatus, reviewer: str, reason: str) -> ActionRecord:
+        with self.transaction() as conn:
+            action = self._action_for_update(conn, action_id)
+            if action.approval_status not in {ApprovalStatus.PENDING, ApprovalStatus.AUTOMATICALLY_APPROVED}: raise ConcurrencyConflict(f'action is already terminal: {action.approval_status}')
+            updated = action.model_copy(update={'approval_status': approval_status, 'reviewer': reviewer, 'reason': reason, 'updated_at': utc_now()}); self._update_action_conn(conn, updated)
+        return updated
+    def _action_for_update(self, conn: Any, action_id: str) -> ActionRecord:
+        row = conn.execute('SELECT payload FROM orchestrator_actions WHERE action_id=%s FOR UPDATE', (action_id,)).fetchone()
+        if not row: raise RecordNotFound(action_id)
+        return ActionRecord.model_validate(row['payload'])
+    def _update_action_conn(self, conn: Any, record: ActionRecord) -> None:
+        conn.execute('UPDATE orchestrator_actions SET approval_status=%s, payload=%s, updated_at=%s WHERE action_id=%s', (record.approval_status.value, self._payload(record), record.updated_at, record.action_id))
+    def mark_action_honeydew_approved(self, action_id: str, *, review_turn_id: str) -> ActionRecord:
+        with self.transaction() as conn:
+            action = self._action_for_update(conn, action_id)
+            if action.approval_status != ApprovalStatus.PENDING: raise ConcurrencyConflict(f'action is not pending: {action.approval_status}')
+            updated = action.model_copy(update={'honeydew_approved': True, 'honeydew_review_turn_id': review_turn_id, 'updated_at': utc_now()}); self._update_action_conn(conn, updated)
+        return updated
+    def mark_action_execution_failed(self, action_id: str, *, reason: str) -> ActionRecord:
+        with self.transaction() as conn:
+            action = self._action_for_update(conn, action_id)
+            if action.approval_status != ApprovalStatus.APPROVED: raise ConcurrencyConflict(f'action is not approved: {action.approval_status}')
+            updated = action.model_copy(update={'approval_status': ApprovalStatus.EXECUTION_FAILED, 'reason': reason, 'updated_at': utc_now()}); self._update_action_conn(conn, updated)
+        return updated
+
+    def create_job_if_absent(self, record: JobRecord) -> tuple[JobRecord, bool]:
+        with self.transaction() as conn:
+            row = conn.execute('SELECT payload FROM orchestrator_jobs WHERE idempotency_key=%s', (record.idempotency_key,)).fetchone()
+            if row: return JobRecord.model_validate(row['payload']), False
+            conn.execute('INSERT INTO orchestrator_jobs (job_id, run_id, action_id, status, idempotency_key, payload, created_at, updated_at) VALUES (%s,%s,%s,%s,%s,%s,%s,%s)', (record.job_id, record.run_id, record.action_id, record.status.value, record.idempotency_key, self._payload(record), record.created_at, record.updated_at))
+        return record, True
+    def update_job(self, record: JobRecord) -> JobRecord:
+        with self.transaction() as conn:
+            result = conn.execute('UPDATE orchestrator_jobs SET status=%s, payload=%s, updated_at=%s WHERE job_id=%s', (record.status.value, self._payload(record), record.updated_at, record.job_id))
+            if result.rowcount != 1: raise RecordNotFound(record.job_id)
+        return record
+    def get_job(self, job_id: str) -> JobRecord:
+        with self._connect() as conn: row = conn.execute('SELECT payload FROM orchestrator_jobs WHERE job_id=%s', (job_id,)).fetchone()
+        if not row: raise RecordNotFound(job_id)
+        return JobRecord.model_validate(row['payload'])
+    def list_jobs(self, run_id: str, *, statuses: Iterable[JobStatus] | None = None) -> list[JobRecord]:
+        query, params = 'SELECT payload FROM orchestrator_jobs WHERE run_id=%s', [run_id]
+        if statuses: query += ' AND status = ANY(%s)'; params.append([s.value for s in statuses])
+        query += ' ORDER BY created_at'
+        with self._connect() as conn: return [JobRecord.model_validate(r['payload']) for r in conn.execute(query, params).fetchall()]
+
+    def save_artifact(self, record: ArtifactRecord) -> ArtifactRecord:
+        return self._save_payload('orchestrator_artifacts', 'artifact_id', record, columns={'run_id': record.run_id, 'job_id': record.job_id, 'created_at': record.created_at})
+    def list_artifacts(self, run_id: str) -> list[ArtifactRecord]:
+        with self._connect() as conn: return [ArtifactRecord.model_validate(r['payload']) for r in conn.execute('SELECT payload FROM orchestrator_artifacts WHERE run_id=%s ORDER BY created_at', (run_id,)).fetchall()]
+    def save_dataset(self, record: IngestedDatasetRecord) -> IngestedDatasetRecord:
+        return self._save_payload('orchestrator_datasets', 'dataset_id', record, columns={'created_at': record.created_at})
+    def get_dataset(self, dataset_id: str) -> IngestedDatasetRecord:
+        with self._connect() as conn: row = conn.execute('SELECT payload FROM orchestrator_datasets WHERE dataset_id=%s', (dataset_id,)).fetchone()
+        if not row: raise RecordNotFound(dataset_id)
+        return IngestedDatasetRecord.model_validate(row['payload'])
+    def list_datasets(self) -> list[IngestedDatasetRecord]:
+        with self._connect() as conn: return [IngestedDatasetRecord.model_validate(r['payload']) for r in conn.execute('SELECT payload FROM orchestrator_datasets ORDER BY created_at').fetchall()]
+    def list_events(self, run_id: str, *, after_sequence: int = 0) -> list[EventRecord]:
+        with self._connect() as conn: return [EventRecord.model_validate(r['payload']) for r in conn.execute('SELECT payload FROM orchestrator_events WHERE run_id=%s AND sequence_number>%s ORDER BY sequence_number', (run_id, after_sequence)).fetchall()]
+
+    def save_knowledge_source(self, record: KnowledgeSource) -> KnowledgeSource:
+        with self.transaction() as conn:
+            conn.execute('INSERT INTO orchestrator_knowledge_sources (source_id, source_type, canonical_uri, run_scope, digest, payload, ingested_at) VALUES (%s,%s,%s,%s,%s,%s,%s) ON CONFLICT (source_id) DO UPDATE SET source_type=EXCLUDED.source_type, canonical_uri=EXCLUDED.canonical_uri, run_scope=EXCLUDED.run_scope, digest=EXCLUDED.digest, payload=EXCLUDED.payload, ingested_at=EXCLUDED.ingested_at', (record.source_id, record.source_type.value, record.canonical_uri, record.run_scope, record.digest, self._payload(record), record.ingested_at))
+        return record
+    def get_knowledge_source(self, source_id: str) -> KnowledgeSource:
+        with self._connect() as conn: row = conn.execute('SELECT payload FROM orchestrator_knowledge_sources WHERE source_id=%s', (source_id,)).fetchone()
+        if not row: raise RecordNotFound(source_id)
+        return KnowledgeSource.model_validate(row['payload'])
+    def find_knowledge_source(self, *, digest: str, canonical_uri: str) -> KnowledgeSource | None:
+        with self._connect() as conn: row = conn.execute('SELECT payload FROM orchestrator_knowledge_sources WHERE digest=%s AND canonical_uri=%s', (digest, canonical_uri)).fetchone()
+        return KnowledgeSource.model_validate(row['payload']) if row else None
+    def list_knowledge_sources(self, *, source_types: Iterable[SourceType] | None = None, run_scope: str | None = None) -> list[KnowledgeSource]:
+        query, params, clauses = 'SELECT payload FROM orchestrator_knowledge_sources', [], []
+        if run_scope is not None: clauses.append('(run_scope=%s OR run_scope IS NULL)'); params.append(run_scope)
+        if source_types: clauses.append('source_type = ANY(%s)'); params.append([x.value for x in source_types])
+        if clauses: query += ' WHERE ' + ' AND '.join(clauses)
+        query += ' ORDER BY ingested_at, source_id'
+        with self._connect() as conn: return [KnowledgeSource.model_validate(r['payload']) for r in conn.execute(query, params).fetchall()]
+    def delete_knowledge_source(self, source_id: str) -> bool:
+        with self.transaction() as conn: return conn.execute('DELETE FROM orchestrator_knowledge_sources WHERE source_id=%s', (source_id,)).rowcount == 1
+    def delete_knowledge_sources_by_digest(self, digest: str) -> int:
+        with self.transaction() as conn: return conn.execute('DELETE FROM orchestrator_knowledge_sources WHERE digest=%s', (digest,)).rowcount
+    def replace_knowledge_chunks(self, source_id: str, chunks: list[KnowledgeChunk]) -> list[KnowledgeChunk]:
+        with self.transaction() as conn:
+            conn.execute('DELETE FROM orchestrator_knowledge_chunks WHERE source_id=%s', (source_id,))
+            for chunk in chunks: conn.execute('INSERT INTO orchestrator_knowledge_chunks (chunk_id, source_id, chunk_index, text, payload) VALUES (%s,%s,%s,%s,%s)', (chunk.chunk_id, chunk.source_id, chunk.chunk_index, chunk.text, self._payload(chunk)))
+        return chunks
+    def list_knowledge_chunks(self, source_id: str) -> list[KnowledgeChunk]:
+        with self._connect() as conn: return [KnowledgeChunk.model_validate(r['payload']) for r in conn.execute('SELECT payload FROM orchestrator_knowledge_chunks WHERE source_id=%s ORDER BY chunk_index', (source_id,)).fetchall()]
+    def search_knowledge_chunks(self, query: str, *, source_ids: list[str] | None = None, limit: int = 10) -> list[dict[str, Any]]:
+        params: list[Any] = [query]; clause = "to_tsvector('simple', text) @@ websearch_to_tsquery('simple', %s)"
+        if source_ids: clause += ' AND source_id = ANY(%s)'; params.append(source_ids)
+        params.append(limit)
+        sql = "SELECT payload, ts_rank_cd(to_tsvector('simple', text), websearch_to_tsquery('simple', %s)) AS rank FROM orchestrator_knowledge_chunks WHERE " + clause + ' ORDER BY rank DESC, chunk_index LIMIT %s'
+        with self._connect() as conn: rows = conn.execute(sql, params).fetchall()
+        return [{**KnowledgeChunk.model_validate(row['payload']).model_dump(mode='json'), 'rank': float(row['rank'])} for row in rows]
+    def save_context_packet(self, packet: ContextPacket) -> ContextPacket:
+        return self._save_payload('orchestrator_context_packets', 'packet_id', packet, columns={'run_id': packet.run_id, 'created_at': packet.created_at})
+    def get_context_packet(self, packet_id: str) -> ContextPacket:
+        with self._connect() as conn: row = conn.execute('SELECT payload FROM orchestrator_context_packets WHERE packet_id=%s', (packet_id,)).fetchone()
+        if not row: raise RecordNotFound(packet_id)
+        return ContextPacket.model_validate(row['payload'])
+    def list_context_packets(self, run_id: str) -> list[ContextPacket]:
+        with self._connect() as conn: return [ContextPacket.model_validate(r['payload']) for r in conn.execute('SELECT payload FROM orchestrator_context_packets WHERE run_id=%s ORDER BY created_at, packet_id', (run_id,)).fetchall()]

--- a/services/research-orchestrator/requirements.txt
+++ b/services/research-orchestrator/requirements.txt
@@ -4,4 +4,5 @@ httpx==0.28.1
 pydantic-settings==2.8.1
 PyYAML==6.0.2
 python-multipart==0.0.20
+psycopg[binary]==3.2.9
 uvicorn[standard]==0.34.0

--- a/services/research-orchestrator/scripts/import-sqlite-store-to-postgres.py
+++ b/services/research-orchestrator/scripts/import-sqlite-store-to-postgres.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""One-time, fail-closed import of an orchestrator SQLite database to Postgres."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sqlite3
+import sys
+
+from app.postgres_store import PostgresStore
+from psycopg.types.json import Jsonb
+
+
+TABLES = (
+    ('runs', 'orchestrator_runs', ('run_id', 'state', 'version', 'payload', 'created_at', 'updated_at')),
+    ('turns', 'orchestrator_turns', ('turn_id', 'run_id', 'status', 'payload', 'created_at', 'updated_at')),
+    ('actions', 'orchestrator_actions', ('action_id', 'run_id', 'approval_status', 'idempotency_key', 'payload', 'created_at', 'updated_at')),
+    ('jobs', 'orchestrator_jobs', ('job_id', 'run_id', 'action_id', 'status', 'idempotency_key', 'payload', 'created_at', 'updated_at')),
+    ('artifacts', 'orchestrator_artifacts', ('artifact_id', 'run_id', 'job_id', 'payload', 'created_at')),
+    ('datasets', 'orchestrator_datasets', ('dataset_id', 'payload', 'created_at')),
+    ('events', 'orchestrator_events', ('event_id', 'run_id', 'sequence_number', 'source', 'event_type', 'payload', 'timestamp')),
+    ('knowledge_sources', 'orchestrator_knowledge_sources', ('source_id', 'source_type', 'canonical_uri', 'run_scope', 'digest', 'payload', 'ingested_at')),
+    ('knowledge_chunks', 'orchestrator_knowledge_chunks', ('chunk_id', 'source_id', 'chunk_index', 'text', 'payload')),
+    ('context_packets', 'orchestrator_context_packets', ('packet_id', 'run_id', 'payload', 'created_at')),
+)
+
+
+def payload_for(source_table: str, row: sqlite3.Row) -> dict:
+    """Normalize the three SQLite tables that did not use a payload column."""
+    if source_table == 'knowledge_sources':
+        return {
+            'source_id': row['source_id'], 'source_type': row['source_type'],
+            'canonical_uri': row['canonical_uri'], 'run_scope': row['run_scope'],
+            'access_policy': row['access_policy'], 'source_version': row['source_version'],
+            'digest': row['digest'], 'ingested_at': row['ingested_at'],
+            'index_version': row['index_version'], 'title': row['title'],
+            'metadata': json.loads(row['metadata']), 'parent_source_id': row['parent_source_id'],
+        }
+    if source_table == 'knowledge_chunks':
+        return {
+            'chunk_id': row['chunk_id'], 'source_id': row['source_id'],
+            'chunk_index': row['chunk_index'], 'text': row['text'],
+            'digest': row['digest'], 'token_count': row['token_count'],
+            'index_version': row['index_version'],
+        }
+    if source_table == 'context_packets':
+        return {
+            'packet_id': row['packet_id'], 'run_id': row['run_id'],
+            'agent': row['agent'], 'turn_number': row['turn_number'],
+            'turn_kind': row['turn_kind'], 'query': row['query'],
+            'index_version': row['index_version'],
+            'ranked_sources': json.loads(row['ranked_sources']),
+            'exact_text_supplied': row['exact_text_supplied'],
+            'token_budget': row['token_budget'], 'created_at': row['created_at'],
+        }
+    return json.loads(row['payload'])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--sqlite-path', required=True)
+    parser.add_argument('--postgres-dsn', required=True)
+    parser.add_argument('--apply', action='store_true', help='perform the import')
+    args = parser.parse_args()
+
+    source_path = Path(args.sqlite_path)
+    if not source_path.is_file():
+        parser.error(f'SQLite database does not exist: {source_path}')
+    if not args.apply:
+        print('dry run: pass --apply to import; no database was changed')
+        return 0
+
+    destination = PostgresStore(args.postgres_dsn)
+    source = sqlite3.connect(source_path)
+    source.row_factory = sqlite3.Row
+    try:
+        with destination.transaction() as conn:
+            existing = conn.execute('SELECT COUNT(*) AS count FROM orchestrator_runs').fetchone()['count']
+            if existing:
+                raise RuntimeError('destination is not empty; refusing to merge an ambiguous SQLite import')
+            for source_table, destination_table, columns in TABLES:
+                exists = source.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (source_table,)).fetchone()
+                if not exists:
+                    continue
+                rows = source.execute(f"SELECT {', '.join(columns)} FROM {source_table}").fetchall()
+                if not rows:
+                    continue
+                placeholders = ', '.join(['%s'] * len(columns))
+                statement = f"INSERT INTO {destination_table} ({', '.join(columns)}) VALUES ({placeholders})"
+                for row in rows:
+                    values = [
+                        Jsonb(payload_for(source_table, row)) if column == 'payload' else row[column]
+                        for column in columns
+                    ]
+                    conn.execute(statement, values)
+                print(f'imported {len(rows)} {source_table} rows')
+    finally:
+        source.close()
+    print('SQLite import completed. Keep the source file until live readiness and recovery checks pass.')
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f'import failed: {exc}', file=sys.stderr)
+        raise SystemExit(1)

--- a/services/research-orchestrator/tests/test_state_and_schemas.py
+++ b/services/research-orchestrator/tests/test_state_and_schemas.py
@@ -135,3 +135,14 @@ def test_comma_separated_image_allowlist_from_environment(
         'ghcr.io/example/runner:a',
         'ghcr.io/example/runner:b',
     ]
+
+
+def test_postgres_backend_requires_an_explicit_dsn() -> None:
+    with pytest.raises(ValueError, match='non-empty store_postgres_dsn'):
+        Settings(store_backend='postgres')
+
+    settings = Settings(
+        store_backend='postgres',
+        store_postgres_dsn='postgresql://glasslab:test@localhost/glasslab',
+    )
+    assert settings.store_backend == 'postgres'


### PR DESCRIPTION
## Summary
- add a PostgreSQL-backed research-orchestrator store with transactional event ordering and SQLite import tooling
- make live manifests select Postgres via a secret DSN; retain SQLite for local smoke tests
- add a concise current Discord operator guide and a conservative post-rollout image tag retention policy

## Validation
- `68 passed`: state, workflow, and knowledge suites
- `35 passed`: Discord and Hermes suites
- `python3 -m compileall`, `bash -n`, and `git diff --check`

## Live migration
The rollout requires a one-time import of the existing SQLite database on `.44` and setting `GLASSLAB_ORCHESTRATOR_STORE_POSTGRES_DSN` in the local orchestrator Secret before applying the new ConfigMap.