### PR TITLE
Complete ccny Glasslab ownership cutover

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Glasslab contributor guide
-    url: https://github.com/OffensiveGeneric/glasslab-cluster-config/blob/main/CONTRIBUTING.md
+    url: https://github.com/ccny-glasslab/glasslab-cluster-config/blob/main/CONTRIBUTING.md
     about: Read the architecture, access, issue, branch, test, and pull-request workflow.

--- a/TODO.md
+++ b/TODO.md
@@ -8,33 +8,33 @@ duplicate complete task specifications or maintain an independent status.
 
 Current issues:
 
-- [all open work](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues)
-- [ready work](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues?q=is%3Aissue%20state%3Aopen%20label%3Astate%3Aready)
-- [newcomer work](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
+- [all open work](https://github.com/ccny-glasslab/glasslab-cluster-config/issues)
+- [ready work](https://github.com/ccny-glasslab/glasslab-cluster-config/issues?q=is%3Aissue%20state%3Aopen%20label%3Astate%3Aready)
+- [newcomer work](https://github.com/ccny-glasslab/glasslab-cluster-config/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
 
 ## P0: Restore The End-To-End Research Loop
 
-- [#104 Prevent missing Honeydew contract metadata from failing a run](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/104)
-- [#92 Add terminal research-run checkpoint retry](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/92)
-- [#100 Complete corrected Wine clustering run](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/100), blocked by #92
+- [#104 Prevent missing Honeydew contract metadata from failing a run](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/104)
+- [#92 Add terminal research-run checkpoint retry](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/92)
+- [#100 Complete corrected Wine clustering run](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/100), blocked by #92
 
 ## P1: Make Operation Observable And Faster
 
-- [#95 Expose structured research-run turn inspection](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/95)
-- [#94 Add Discord research run status and discovery commands](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/94)
-- [#93 Compact research-agent evidence prompts](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/93)
-- [#99 Add research runtime storage retention and cache cleanup](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/99)
+- [#95 Expose structured research-run turn inspection](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/95)
+- [#94 Add Discord research run status and discovery commands](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/94)
+- [#93 Compact research-agent evidence prompts](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/93)
+- [#99 Add research runtime storage retention and cache cleanup](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/99)
 
 ## P1: Validate General Research Tasks
 
-- [#98 Validate an arbitrary-dataset research workflow end to end](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/98)
-- [#101 Complete Fashion-MNIST compatibility run](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/101)
-- [#96 Evaluate Hermes as a research-agent runtime adapter](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/96)
+- [#98 Validate an arbitrary-dataset research workflow end to end](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/98)
+- [#101 Complete Fashion-MNIST compatibility run](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/101)
+- [#96 Evaluate Hermes as a research-agent runtime adapter](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/96)
 
 ## P2: Durability And Maintenance
 
-- [#97 Plan PostgreSQL migration for the research orchestrator](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/97)
-- [#102 Consolidate current docs and triage legacy issues](https://github.com/OffensiveGeneric/glasslab-cluster-config/issues/102)
+- [#97 Plan PostgreSQL migration for the research orchestrator](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/97)
+- [#102 Consolidate current docs and triage legacy issues](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/102)
 
 ## Maintenance Rule
 

--- a/docs/contributor-access.md
+++ b/docs/contributor-access.md
@@ -66,7 +66,7 @@ After authenticating the GitHub CLI, create a personal checkout:
 
 ```bash
 cd ~
-gh repo clone OffensiveGeneric/glasslab-cluster-config cluster-config
+gh repo clone ccny-glasslab/glasslab-cluster-config cluster-config
 cd ~/cluster-config
 git switch -c <personal-feature-branch>
 ```

--- a/docs/version-control.md
+++ b/docs/version-control.md
@@ -14,7 +14,7 @@ What is intentionally not tracked:
 
 Git remote:
 
-- `origin` is reserved for `git@github-cluster-config:OffensiveGeneric/glasslab-cluster-config.git`
+- `origin` is reserved for `git@github-cluster-config:ccny-glasslab/glasslab-cluster-config.git`
 - SSH uses the dedicated provisioner key `~/.ssh/id_ed25519_github_cluster_config`
 
 Typical workflow:

--- a/kubeadm/glasslab-v2/research-orchestrator/20-deployment.yaml
+++ b/kubeadm/glasslab-v2/research-orchestrator/20-deployment.yaml
@@ -36,7 +36,7 @@ spec:
               mkdir -p "$(dirname "$target")"
               if [ ! -d "$target/.git" ]; then
                 git clone --branch main --single-branch \
-                  https://github.com/OffensiveGeneric/glasslab-cluster-config.git \
+                  https://github.com/ccny-glasslab/glasslab-cluster-config.git \
                   "$target"
               fi
               git -C "$target" fetch origin main

--- a/scripts/create-ghcr-pull-secret.sh
+++ b/scripts/create-ghcr-pull-secret.sh
@@ -5,7 +5,7 @@ KUBECTL="${KUBECTL:-kubectl}"
 NAMESPACE="${GLASSLAB_V2_NAMESPACE:-glasslab-v2}"
 SECRET_NAME="${GLASSLAB_GHCR_PULL_SECRET_NAME:-glasslab-ghcr-pull}"
 REGISTRY_HOST="${GLASSLAB_WORKFLOW_API_REGISTRY_HOST:-ghcr.io}"
-REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-OffensiveGeneric}}"
+REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-ccny-glasslab}}"
 REGISTRY_TOKEN="${GHCR_TOKEN:-}"
 
 usage() {
@@ -16,7 +16,7 @@ Create or refresh the private GHCR Docker registry secret used by Glasslab v2.
 
 Environment:
   GHCR_TOKEN    GitHub token with package read access
-  GHCR_USERNAME Registry username. Defaults to OffensiveGeneric.
+  GHCR_USERNAME Registry username. Defaults to ccny-glasslab.
 USAGE
 }
 

--- a/scripts/push-bounded-agent-images.sh
+++ b/scripts/push-bounded-agent-images.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REGISTRY_HOST="${GLASSLAB_AGENT_REGISTRY_HOST:-ghcr.io}"
-REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-OffensiveGeneric}}"
+REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-ccny-glasslab}}"
 REGISTRY_TOKEN="${GHCR_TOKEN:-}"
 
 INTAKE_IMAGE_REF="${GLASSLAB_INTAKE_AGENT_IMAGE_REF:-ghcr.io/ccny-glasslab/glasslab-intake-agent:0.1.0}"
@@ -20,7 +20,7 @@ Build and push the bounded stage-agent images to GHCR.
 
 Environment:
   GHCR_TOKEN    GitHub token with package write access
-  GHCR_USERNAME Registry username. Defaults to OffensiveGeneric.
+  GHCR_USERNAME Registry username. Defaults to ccny-glasslab.
 USAGE
 }
 

--- a/scripts/push-gpu-experiment-runner-image.sh
+++ b/scripts/push-gpu-experiment-runner-image.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IMAGE_REF="${GLASSLAB_GPU_EXPERIMENT_RUNNER_IMAGE_REF:-ghcr.io/ccny-glasslab/glasslab-gpu-experiment-runner:0.1.1}"
 REGISTRY_HOST="${GLASSLAB_GPU_EXPERIMENT_RUNNER_REGISTRY_HOST:-ghcr.io}"
-REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-OffensiveGeneric}}"
+REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-ccny-glasslab}}"
 REGISTRY_TOKEN="${GHCR_TOKEN:-}"
 
 usage() {
@@ -15,7 +15,7 @@ Build the GPU experiment runner image locally and push it to GHCR.
 
 Environment:
   GHCR_TOKEN    GitHub token with package write access
-  GHCR_USERNAME Registry username. Defaults to OffensiveGeneric.
+  GHCR_USERNAME Registry username. Defaults to ccny-glasslab.
 USAGE
 }
 

--- a/scripts/push-literature-runner-image.sh
+++ b/scripts/push-literature-runner-image.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IMAGE_REF="${GLASSLAB_LITERATURE_RUNNER_IMAGE_REF:-ghcr.io/ccny-glasslab/glasslab-literature-runner:0.1.2}"
 REGISTRY_HOST="${GLASSLAB_LITERATURE_RUNNER_REGISTRY_HOST:-ghcr.io}"
-REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-OffensiveGeneric}}"
+REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-ccny-glasslab}}"
 REGISTRY_TOKEN="${GHCR_TOKEN:-}"
 
 usage() {
@@ -15,7 +15,7 @@ Build the literature runner image locally and push it to GHCR.
 
 Environment:
   GHCR_TOKEN    GitHub token with package write access
-  GHCR_USERNAME Registry username. Defaults to OffensiveGeneric.
+  GHCR_USERNAME Registry username. Defaults to ccny-glasslab.
 USAGE
 }
 

--- a/scripts/push-metric-search-image.sh
+++ b/scripts/push-metric-search-image.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IMAGE_REF="${GLASSLAB_METRIC_SEARCH_IMAGE_REF:-ghcr.io/ccny-glasslab/glasslab-metric-search:latest}"
 REGISTRY_HOST="${GLASSLAB_METRIC_SEARCH_REGISTRY_HOST:-ghcr.io}"
-REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-OffensiveGeneric}}"
+REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-ccny-glasslab}}"
 REGISTRY_TOKEN="${GHCR_TOKEN:-}"
 
 usage() {
@@ -16,7 +16,7 @@ Build the metric-search image locally and push it to GHCR.
 Environment:
   GLASSLAB_METRIC_SEARCH_IMAGE_REF  Image reference with tag
   GHCR_TOKEN    GitHub token with package write access
-  GHCR_USERNAME Registry username. Defaults to OffensiveGeneric.
+  GHCR_USERNAME Registry username. Defaults to ccny-glasslab.
 USAGE
 }
 

--- a/scripts/push-research-command-router-image.sh
+++ b/scripts/push-research-command-router-image.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IMAGE_REF="${GLASSLAB_RESEARCH_COMMAND_ROUTER_IMAGE_REF:-ghcr.io/ccny-glasslab/glasslab-research-command-router:0.1.0}"
 REGISTRY_HOST="${GLASSLAB_RESEARCH_COMMAND_ROUTER_REGISTRY_HOST:-ghcr.io}"
-REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-OffensiveGeneric}}"
+REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-ccny-glasslab}}"
 REGISTRY_TOKEN="${GHCR_TOKEN:-}"
 
 usage() {
@@ -15,7 +15,7 @@ Build the research-command-router image locally and push it to GHCR.
 
 Environment:
   GHCR_TOKEN    GitHub token with package write access
-  GHCR_USERNAME Registry username. Defaults to OffensiveGeneric.
+  GHCR_USERNAME Registry username. Defaults to ccny-glasslab.
 USAGE
 }
 

--- a/scripts/push-research-ingress-image.sh
+++ b/scripts/push-research-ingress-image.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IMAGE_REF="${GLASSLAB_RESEARCH_INGRESS_IMAGE_REF:-ghcr.io/ccny-glasslab/glasslab-research-ingress:0.1.0}"
 REGISTRY_HOST="${GLASSLAB_RESEARCH_INGRESS_REGISTRY_HOST:-ghcr.io}"
-REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-OffensiveGeneric}}"
+REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-ccny-glasslab}}"
 REGISTRY_TOKEN="${GHCR_TOKEN:-}"
 
 usage() {

--- a/scripts/push-tabular-runner-image.sh
+++ b/scripts/push-tabular-runner-image.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IMAGE_REF="${GLASSLAB_TABULAR_RUNNER_IMAGE_REF:-ghcr.io/ccny-glasslab/glasslab-tabular-runner:0.1.2}"
 REGISTRY_HOST="${GLASSLAB_TABULAR_RUNNER_REGISTRY_HOST:-ghcr.io}"
-REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-OffensiveGeneric}}"
+REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-ccny-glasslab}}"
 REGISTRY_TOKEN="${GHCR_TOKEN:-}"
 
 usage() {
@@ -15,7 +15,7 @@ Build the tabular runner image locally and push it to GHCR.
 
 Environment:
   GHCR_TOKEN    GitHub token with package write access
-  GHCR_USERNAME Registry username. Defaults to OffensiveGeneric.
+  GHCR_USERNAME Registry username. Defaults to ccny-glasslab.
 USAGE
 }
 

--- a/scripts/push-whatsapp-gateway-image.sh
+++ b/scripts/push-whatsapp-gateway-image.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IMAGE_REF="${GLASSLAB_WHATSAPP_GATEWAY_IMAGE_REF:-ghcr.io/ccny-glasslab/glasslab-whatsapp-gateway:0.1.0}"
 REGISTRY_HOST="${GLASSLAB_WHATSAPP_GATEWAY_REGISTRY_HOST:-ghcr.io}"
-REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-OffensiveGeneric}}"
+REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-ccny-glasslab}}"
 REGISTRY_TOKEN="${GHCR_TOKEN:-}"
 
 usage() {

--- a/scripts/push-workflow-api-image.sh
+++ b/scripts/push-workflow-api-image.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IMAGE_REF="${GLASSLAB_WORKFLOW_API_IMAGE_REF:-ghcr.io/ccny-glasslab/glasslab-workflow-api:0.1.11}"
 REGISTRY_HOST="${GLASSLAB_WORKFLOW_API_REGISTRY_HOST:-ghcr.io}"
-REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-OffensiveGeneric}}"
+REGISTRY_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-ccny-glasslab}}"
 REGISTRY_TOKEN="${GHCR_TOKEN:-}"
 GIT_SHA="${GLASSLAB_GIT_SHA:-$(git -C "$ROOT_DIR" rev-parse --short HEAD)}"
 BUILD_SOURCE="${GLASSLAB_BUILD_SOURCE:-git:${GIT_SHA}}"
@@ -17,7 +17,7 @@ Build the workflow-api image locally and push it to GHCR.
 
 Environment:
   GHCR_TOKEN    GitHub token with package write access
-  GHCR_USERNAME Registry username. Defaults to OffensiveGeneric.
+  GHCR_USERNAME Registry username. Defaults to ccny-glasslab.
 USAGE
 }
 

--- a/scripts/request-service-image.sh
+++ b/scripts/request-service-image.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPOSITORY="${GLASSLAB_GITHUB_REPOSITORY:-OffensiveGeneric/glasslab-cluster-config}"
+REPOSITORY="${GLASSLAB_GITHUB_REPOSITORY:-ccny-glasslab/glasslab-cluster-config}"
 WORKFLOW="${GLASSLAB_IMAGE_WORKFLOW:-manual-docker.yml}"
 
 usage() {

--- a/services/intake-agent/seeds/glasslab_paper_harvester_seed_manifest.yaml
+++ b/services/intake-agent/seeds/glasslab_paper_harvester_seed_manifest.yaml
@@ -3,8 +3,8 @@ name: glasslab_paper_harvester_seed_manifest
 created_on: '2026-03-25'
 owner_project: glasslab-cluster-config
 repo_context:
-  repo_url: https://github.com/OffensiveGeneric/glasslab-cluster-config
-  reference_doc: https://github.com/OffensiveGeneric/glasslab-cluster-config/blob/main/docs/titanic-agent-stack.md
+  repo_url: https://github.com/ccny-glasslab/glasslab-cluster-config
+  reference_doc: https://github.com/ccny-glasslab/glasslab-cluster-config/blob/main/docs/titanic-agent-stack.md
   architecture_bias:
   - favor bounded, reproducible jobs that fit a Kubernetes job runner
   - prefer papers with public code, public benchmarks, and clear artifact outputs

--- a/services/research-orchestrator/Dockerfile
+++ b/services/research-orchestrator/Dockerfile
@@ -21,7 +21,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 ARG GLASSLAB_GIT_SHA=unknown
 ARG GLASSLAB_BUILD_SOURCE=unspecified
 LABEL org.opencontainers.image.revision="${GLASSLAB_GIT_SHA}"
-LABEL org.opencontainers.image.source="https://github.com/OffensiveGeneric/glasslab-cluster-config"
+LABEL org.opencontainers.image.source="https://github.com/ccny-glasslab/glasslab-cluster-config"
 LABEL io.glasslab.build-source="${GLASSLAB_BUILD_SOURCE}"
 
 COPY app ./app

--- a/services/workflow-api/Dockerfile
+++ b/services/workflow-api/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 ARG GLASSLAB_GIT_SHA=unknown
 ARG GLASSLAB_BUILD_SOURCE=unspecified
 LABEL org.opencontainers.image.revision="${GLASSLAB_GIT_SHA}"
-LABEL org.opencontainers.image.source="https://github.com/OffensiveGeneric/glasslab-cluster-config"
+LABEL org.opencontainers.image.source="https://github.com/ccny-glasslab/glasslab-cluster-config"
 LABEL io.glasslab.build-source="${GLASSLAB_BUILD_SOURCE}"
 ENV \
     GLASSLAB_WORKFLOW_API_BUILD_SOURCE_REVISION=${GLASSLAB_GIT_SHA} \


### PR DESCRIPTION
## Summary
- move every cluster-config GitHub URL, clone source, OCI source label, and GHCR publisher default to `ccny-glasslab`
- retain only verified separate-repository references to `OffensiveGeneric/glasslab-metric-search`
- `.44` has both `origin` and `github-ssh` remotes set to the new canonical repository

## Validation
- `git grep` leaves only the verified separate-repository references
- `git diff --check`
- shell syntax checks for changed image/publisher scripts