### PR TITLE
Package orchestrator store migration tooling

### DIFF
--- a/services/research-orchestrator/Dockerfile
+++ b/services/research-orchestrator/Dockerfile
@@ -27,6 +27,9 @@ LABEL io.glasslab.build-source="${GLASSLAB_BUILD_SOURCE}"
 COPY app ./app
 COPY prompts ./prompts
 COPY evaluation-contracts ./evaluation-contracts
+# Operational migration tooling is part of the reviewed image so a live store
+# cutover does not depend on copying executable files into a running pod.
+COPY scripts ./scripts
 
 RUN useradd --uid 10001 --create-home orchestrator \
     && mkdir -p /var/lib/glasslab-research-orchestrator \


### PR DESCRIPTION
## Summary
- copy the reviewed SQLite-to-Postgres importer into the research-orchestrator image
- avoid ad-hoc executable file injection during the live state-store cutover

## Validation
- confirmed importer is present in the Docker build context
- `git diff --check`