### PR TITLE
Make orchestrator importer runnable from image

### DIFF
--- a/services/research-orchestrator/scripts/import-sqlite-store-to-postgres.py
+++ b/services/research-orchestrator/scripts/import-sqlite-store-to-postgres.py
@@ -9,6 +9,13 @@ from pathlib import Path
 import sqlite3
 import sys
 
+# When invoked as ``python scripts/...``, Python puts ``scripts`` rather than
+# the service root on sys.path. Resolve the adjacent app package explicitly so
+# the image-bundled operational tool works from any current directory.
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
 from app.postgres_store import PostgresStore
 from psycopg.types.json import Jsonb
 


### PR DESCRIPTION
## Summary
- add the service root to `sys.path` when the bundled importer is run by path
- fixes `ModuleNotFoundError: app` observed in the live import pod before any database records were written

## Validation
- Python syntax compilation
- `git diff --check`