### PR TITLE
fix: harden Hermes structured-output failure handling

### DIFF
--- a/docs/research-orchestrator.md
+++ b/docs/research-orchestrator.md
@@ -178,6 +178,39 @@ Evidence references must use `artifact://`, `git://`, or `event://`. A turn
 cannot establish that a job ran. Only persisted job and artifact records can do
 that.
 
+### Structured-output failure handling
+
+The orchestrator validates every turn and never infers intent from prose. A
+turn that is malformed, schema-invalid, or of the wrong `kind` is rejected
+rather than trusted, and each failure is distinguishable in the durable event
+log:
+
+- A turn that returns no JSON, unparseable JSON, or JSON that fails
+  `AgentTurnResult` validation raises a runtime error whose `failure_class` is
+  `not_text`, `malformed_json`, or `schema_invalid` respectively. The failed
+  turn is recorded as `agent.turn_completed` with `status: failed` and that
+  `failure_class` in the payload.
+- A turn that validates but returns the wrong `kind` (for example
+  `verification` where `protocol_draft` was required) is recorded as
+  `agent.output_rejected` with both `returned_kind` and `expected_kind`. The
+  orchestrator issues exactly one focused repair turn that names the only
+  allowed kind, then fails the run if the repair is still wrong.
+
+A repair turn is always placed after any retrieved/context material and may
+only request actions that the policy layer already authorizes; it cannot
+advance state or duplicate an action or job on its own. A protocol draft that
+returns a valid `protocol_draft` but declares no produced `protocol` file — the
+live contract violation observed in run `7a1cef60dd3b49e0b565759ea988edb6` — is
+rejected as `agent.output_rejected` and repaired with one focused turn that
+names `program.md`, requires purpose `protocol`, and forbids actions. The
+repair is revalidated (exactly one declared protocol file that exists on disk)
+before the run may advance to `AWAITING_PROTOCOL_APPROVAL`.
+
+Known limitation: the focused repair is a single turn per failure class. A
+runtime that repeats the same failure in its repair turn ends the run
+`FAILED` rather than looping; resuming from a terminal state is not yet
+supported and is tracked as terminal-checkpoint retry (#92).
+
 ## Evaluation Integrity
 
 Contracts live under

--- a/services/research-orchestrator/app/engine.py
+++ b/services/research-orchestrator/app/engine.py
@@ -762,13 +762,14 @@ class ResearchOrchestrator:
                     workspace=workspace,
                     session_id=session.session_id,
                     prompt=(
-                        'Structured kind correction. Your previous response '
-                        f'used kind `{returned_kind.value}`, but this turn '
-                        f'requires kind `{expected_kind.value}`. Complete the '
-                        'original task and return a complete AgentTurnResult '
-                        'with exactly that kind. Do not repeat an earlier '
-                        'workflow phase.\n\nOriginal task:\n'
-                        + prompt
+                        prompt
+                        + '\n\nStructured kind correction. Your previous '
+                        f'response used kind `{returned_kind.value}`, but this '
+                        f'turn requires kind `{expected_kind.value}` and no '
+                        'other. Complete the original task and return a '
+                        'complete AgentTurnResult with exactly that kind. Do '
+                        'not repeat an earlier workflow phase and do not '
+                        'request actions.'
                     ),
                 )
                 if result.kind != expected_kind:
@@ -815,6 +816,7 @@ class ResearchOrchestrator:
                 }
             )
             self.store.save_turn(failed)
+            failure_class = getattr(exc, 'failure_class', None)
             self._event(
                 run_id,
                 source=agent.value,
@@ -823,6 +825,7 @@ class ResearchOrchestrator:
                     'turn_id': turn.turn_id,
                     'status': 'failed',
                     'error': str(exc),
+                    'failure_class': failure_class,
                 },
             )
             self._rotate_agent_session(
@@ -1201,6 +1204,52 @@ class ResearchOrchestrator:
         protocol_files = [
             item for item in result.produced_files if item.purpose == 'protocol'
         ]
+        if not protocol_files:
+            # Honeydew returned a formally valid protocol_draft turn but declared
+            # no protocol file at all. This is a contract violation distinct from
+            # a declared-but-missing file (handled below): the workspace action
+            # was never attempted, so the repair must name the exact file and
+            # purpose and revalidate before the run may advance.
+            self._event(
+                run_id,
+                source='orchestrator',
+                event_type='agent.output_rejected',
+                payload={
+                    'turn_id': turn.turn_id,
+                    'expected_field': 'produced_files',
+                    'expected_purpose': 'protocol',
+                    'repair_attempted': True,
+                },
+            )
+            _, result = self._run_agent_turn(
+                run_id=run_id,
+                agent=AgentName.HONEYDEW,
+                prompt=(
+                    'Focused protocol-file repair. Your previous protocol_draft '
+                    'turn did not declare any produced protocol file. Write '
+                    '`program.md` in your workspace now, then read it back to '
+                    'confirm it exists. Declare exactly that file in '
+                    '`produced_files` with purpose `protocol` and request no '
+                    'actions. Do not redesign the protocol. Return kind '
+                    '`protocol_draft` only after the file is written and '
+                    'verified.'
+                ),
+                expected_kind=TurnKind.PROTOCOL_DRAFT,
+                input_event={
+                    'repair': 'missing_protocol_declaration',
+                    'required_path': 'program.md',
+                    'required_purpose': 'protocol',
+                },
+            )
+            protocol_files = [
+                item
+                for item in result.produced_files
+                if item.purpose == 'protocol'
+            ]
+            if result.requested_actions:
+                raise WorkflowError(
+                    'Honeydew protocol-file repair must request no actions'
+                )
         if len(protocol_files) != 1:
             # Exactly one declared protocol file keeps the artifact binding
             # unambiguous; a declared-but-missing file is repaired below rather

--- a/services/research-orchestrator/app/hermes_runtime.py
+++ b/services/research-orchestrator/app/hermes_runtime.py
@@ -20,7 +20,17 @@ from .schemas import AgentName, AgentTurnResult
 
 
 class HermesRuntimeError(RuntimeError):
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_class: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        # Machine-readable classifier so the engine can distinguish
+        # malformed output from schema-invalid output from a wrong turn kind
+        # in durable normalized events, without string-matching the message.
+        self.failure_class = failure_class
 
 
 @dataclass
@@ -47,7 +57,10 @@ def _structured_prompt(prompt: str) -> str:
 
 def _decode_structured_output(output: Any) -> AgentTurnResult:
     if not isinstance(output, str):
-        raise HermesRuntimeError('Hermes run output was not text')
+        raise HermesRuntimeError(
+            'Hermes run output was not text',
+            failure_class='not_text',
+        )
     candidate = output.strip()
     if candidate.startswith('```') and candidate.endswith('```'):
         lines = candidate.splitlines()
@@ -56,7 +69,8 @@ def _decode_structured_output(output: Any) -> AgentTurnResult:
         payload = json.loads(candidate)
     except json.JSONDecodeError as exc:
         raise HermesRuntimeError(
-            'Hermes turn did not return a JSON object'
+            'Hermes turn did not return a JSON object',
+            failure_class='malformed_json',
         ) from exc
     try:
         return AgentTurnResult.model_validate(payload)
@@ -66,7 +80,8 @@ def _decode_structured_output(output: Any) -> AgentTurnResult:
             for item in exc.errors(include_url=False, include_input=False)[:8]
         )
         raise HermesRuntimeError(
-            f'Hermes structured output failed validation: {details}'
+            f'Hermes structured output failed validation: {details}',
+            failure_class='schema_invalid',
         ) from exc
 
 

--- a/services/research-orchestrator/tests/test_hermes_runtime.py
+++ b/services/research-orchestrator/tests/test_hermes_runtime.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import httpx
+import pytest
 import yaml
 
 from app.config import Settings
@@ -201,3 +202,21 @@ def test_hermes_structured_output_accepts_plain_or_fenced_json() -> None:
     assert _decode_structured_output(
         f'```json\n{payload}\n```'
     ).kind == TurnKind.VERIFICATION
+
+
+def test_hermes_structured_output_failures_are_distinguishable() -> None:
+    from app.hermes_runtime import HermesRuntimeError
+
+    with pytest.raises(HermesRuntimeError) as not_text:
+        _decode_structured_output(['not', 'a', 'string'])
+    assert not_text.value.failure_class == 'not_text'
+
+    with pytest.raises(HermesRuntimeError) as malformed:
+        _decode_structured_output('this is not json')
+    assert malformed.value.failure_class == 'malformed_json'
+
+    with pytest.raises(HermesRuntimeError) as invalid:
+        _decode_structured_output(
+            json.dumps({'kind': 'protocol_draft', 'summary': ''})
+        )
+    assert invalid.value.failure_class == 'schema_invalid'

--- a/services/research-orchestrator/tests/test_workflow.py
+++ b/services/research-orchestrator/tests/test_workflow.py
@@ -374,6 +374,57 @@ class MissingContractProposalThenRepairRuntime(ScriptedMockRuntime):
         return result, message_id
 
 
+class MissingProtocolDeclarationThenRepairRuntime(ScriptedMockRuntime):
+    # Honeydew's first protocol_draft turn declares no produced protocol file
+    # (and no program.md exists on disk), reproducing the live contract
+    # violation where a formally valid turn skipped the required workspace
+    # action. The focused repair turn must name program.md and produce it.
+    def __init__(self, *, runner_image: str) -> None:
+        super().__init__(runner_image=runner_image)
+        self.omitted_protocol_once = False
+
+    def run_turn(self, **kwargs):
+        prompt = kwargs['prompt']
+        if 'Focused protocol-file repair' in prompt:
+            return super().run_turn(
+                **{
+                    **kwargs,
+                    'prompt': 'Draft a concrete program.md',
+                }
+            )
+        result, message_id = super().run_turn(**kwargs)
+        if (
+            kwargs['agent'] == AgentName.HONEYDEW
+            and 'Draft a concrete program.md' in prompt
+            and not self.omitted_protocol_once
+        ):
+            (kwargs['workspace'] / 'program.md').unlink(missing_ok=True)
+            result.produced_files = []
+            self.omitted_protocol_once = True
+        return result, message_id
+
+
+class RepeatedWrongKindRuntime(ScriptedMockRuntime):
+    # Honeydew returns a valid-but-wrong kind on every protocol-draft attempt,
+    # exhausting the single focused repair and proving the run fails safely
+    # without advancing state or requesting any action/job.
+    def run_turn(self, **kwargs):
+        self.turn_counts[kwargs['agent']] += 1
+        if (
+            kwargs['agent'] == AgentName.HONEYDEW
+            and 'Draft a concrete program.md' in kwargs['prompt']
+        ):
+            return (
+                AgentTurnResult(
+                    kind=TurnKind.VERIFICATION,
+                    summary='Persistently wrong kind.',
+                    done=True,
+                ),
+                'mock-wrong-kind',
+            )
+        return super().run_turn(**kwargs)
+
+
 class PauseDuringImplementationRuntime(ScriptedMockRuntime):
     # Injects a pause from inside the running Beaker turn, exercising the
     # pause-during-turn path where pause bypasses the advancement lock.
@@ -869,6 +920,53 @@ def test_missing_honeydew_protocol_file_gets_one_focused_repair(
     assert 'agent.file_repair_requested' in event_types
     assert 'agent.file_repair_completed' in event_types
     assert runtime.turn_counts[AgentName.HONEYDEW] == 2
+
+
+def test_missing_protocol_declaration_gets_one_focused_repair(
+    orchestrator_bundle,
+) -> None:
+    _, store, _, _, engine = orchestrator_bundle
+    runtime = MissingProtocolDeclarationThenRepairRuntime(
+        runner_image=RUNNER_IMAGE
+    )
+    engine.runtime = runtime
+
+    run = engine.create_run(
+        RunCreateRequest(objective='Repair a missing protocol declaration.')
+    )
+
+    current = store.get_run(run.run_id)
+    assert current.state == RunState.AWAITING_PROTOCOL_APPROVAL
+    assert Path(current.protocol_path or '').is_file()
+    assert runtime.omitted_protocol_once
+    event_types = {
+        event.event_type for event in store.list_events(run.run_id)
+    }
+    assert 'agent.output_rejected' in event_types
+    assert runtime.turn_counts[AgentName.HONEYDEW] == 2
+
+
+def test_repeated_wrong_kind_fails_without_advancing(
+    orchestrator_bundle,
+) -> None:
+    _, store, cluster, _, engine = orchestrator_bundle
+    runtime = RepeatedWrongKindRuntime(runner_image=RUNNER_IMAGE)
+    engine.runtime = runtime
+
+    with pytest.raises(WorkflowError):
+        engine.create_run(
+            RunCreateRequest(objective='Wrong kind on every draft attempt.')
+        )
+
+    run = next(iter(store.list_runs()))
+    assert run.state == RunState.FAILED
+    assert runtime.turn_counts[AgentName.HONEYDEW] == 2
+    # The failed run must not have advanced: no approval action, no submitted
+    # job, and no duplicated event stream beyond the two attempted turns.
+    actions = store.list_actions(run.run_id)
+    assert all(action.type != 'approve_protocol' for action in actions)
+    assert not store.list_jobs(run.run_id)
+    assert not cluster.submissions
 
 
 def test_missing_contract_proposal_gets_one_focused_repair(


### PR DESCRIPTION
## What was observed

Two live failures against the Hermes inner runtime:

1. **Wrong turn kind** — Honeydew returned a valid JSON turn of `verification` where the workflow required `protocol_draft`. The orchestrator rejected it, but the repair handling was buried and the failure classes were not distinguishable in events.
2. **Valid turn, missing workspace artifact** — run `7a1cef60dd3b49e0b565759ea988edb6` returned a successful `protocol_draft` turn whose summary was `"No previous turn to correct"`, but it created no `protocol/program.md`. The orchestrator correctly refused to advance (`Honeydew must produce exactly one protocol file`) and the run ended `FAILED` with no repair attempt.

## How it is now handled

- **Wrong-kind** turns are recorded as `agent.output_rejected` with both `returned_kind` and `expected_kind`. A single focused repair names the only allowed kind and forbids actions; the correction instruction is appended *after* retrieved/context material (injection-hardening). Repeating the wrong kind ends the run `FAILED` without advancing.
- **Missing protocol file** — a `protocol_draft` turn that declares no produced `protocol` file is rejected as `agent.output_rejected` and repaired with one turn that explicitly names `program.md`, requires purpose `protocol`, and forbids actions. The repair is revalidated (exactly one declared file that exists on disk) before advancing to `AWAITING_PROTOCOL_APPROVAL`.
- **Distinguishable failures** — `HermesRuntimeError` now carries a `failure_class` (`not_text` / `malformed_json` / `schema_invalid`), recorded in the `agent.turn_completed` event payload so malformed vs schema-invalid vs wrong-kind are separable without string-matching.

## Tests added

- `test_missing_protocol_declaration_gets_one_focused_repair` — zero declared protocol file repaired to exactly one existing file.
- `test_repeated_wrong_kind_fails_without_advancing` — wrong kind on every attempt ends `FAILED` with no approval action, no job, no duplicate events.
- `test_hermes_structured_output_failures_are_distinguishable` — the three failure classes.

## Commands / results

```
python3 -m py_compile services/research-orchestrator/app/engine.py services/research-orchestrator/app/hermes_runtime.py
# OK

cd services/research-orchestrator
.venv314/bin/python -m pytest tests/ -q
# 150 passed

python3 scripts/check-doc-links.py
# Markdown links resolved successfully.
```

## Untested live assumptions

- The focused repair is a single turn per failure class (the runtime-level `hermes_structured_repair_attempts` retries malformed/schema-invalid output, but wrong-kind and missing-file repairs are one-shot at the engine). This was not exercised against a live Hermes gateway.
- The repair prompt wording is Hermes-agnostic and relies on Hermes honoring `produced_files` the same way OpenCode did; not yet verified against the live gateway.

Does not modify Kubernetes manifests, deployment scripts, credentials, evaluation contracts, or RAG code.