### PR TITLE
fix: degrade workflow-api run status when Kubernetes live lookup is unavailable

### DIFF
--- a/services/workflow-api/app/job_submission.py
+++ b/services/workflow-api/app/job_submission.py
@@ -16,13 +16,42 @@ from hashlib import sha256
 import json
 from pathlib import Path, PurePosixPath
 import re
-
+import socket
+import ssl
 from typing import Any
+
+import urllib3
 
 from services.common.schemas import RunManifest, RunStatus
 
 from .config import Settings
 from .schemas import JobSubmissionReceipt, LogEntry, RunRecord
+
+
+class LiveStatusUnavailableError(Exception):
+    """The Kubernetes live-status lookup failed for an expected infrastructure
+    reason (API error, DNS/connection failure, or TLS transport failure).
+
+    Raised instead of returning a fabricated status so callers can surface the
+    durable stored status with an explicit degradation note. Deliberately not a
+    subclass of the transport exceptions below, and never raised for
+    programming errors, which continue to propagate unchanged.
+    """
+
+
+# Transport exceptions the Kubernetes Python client raises for expected
+# infrastructure outages, kept distinct from ApiException and from unrelated
+# programming errors. urllib3.MaxRetryError is the umbrella for DNS,
+# connection-refused, timeout, and TLS failures; the narrower classes cover
+# the raw stdlib equivalents that occasionally escape urllib3's wrapping.
+_KUBE_TRANSPORT_EXCEPTIONS = (
+    urllib3.exceptions.MaxRetryError,
+    urllib3.exceptions.NewConnectionError,
+    urllib3.exceptions.ConnectionError,
+    urllib3.exceptions.SSLError,
+    ssl.SSLError,
+    socket.gaierror,
+)
 
 
 def workflow_submission_ready(workflow: RunManifest | Any) -> tuple[bool, list[str]]:
@@ -764,8 +793,14 @@ class KubernetesJobSubmitter(JobSubmitter):
                 name=record.job_submission.job_name,
                 namespace=record.job_submission.namespace,
             )
-        except self.api_exception:
-            return None
+        except self.api_exception as exc:
+            raise LiveStatusUnavailableError(
+                'Kubernetes API error during live status lookup'
+            ) from exc
+        except _KUBE_TRANSPORT_EXCEPTIONS as exc:
+            raise LiveStatusUnavailableError(
+                'Kubernetes transport failure during live status lookup'
+            ) from exc
 
         now = datetime.now(timezone.utc)
         status = job.status

--- a/services/workflow-api/app/job_submission.py
+++ b/services/workflow-api/app/job_submission.py
@@ -43,11 +43,14 @@ class LiveStatusUnavailableError(Exception):
 # infrastructure outages, kept distinct from ApiException and from unrelated
 # programming errors. urllib3.MaxRetryError is the umbrella for DNS,
 # connection-refused, timeout, and TLS failures; the narrower classes cover
-# the raw stdlib equivalents that occasionally escape urllib3's wrapping.
+# connection timeouts, read timeouts, and the raw stdlib equivalents that
+# occasionally escape urllib3's wrapping.
 _KUBE_TRANSPORT_EXCEPTIONS = (
     urllib3.exceptions.MaxRetryError,
     urllib3.exceptions.NewConnectionError,
     urllib3.exceptions.ConnectionError,
+    urllib3.exceptions.ConnectTimeoutError,
+    urllib3.exceptions.ReadTimeoutError,
     urllib3.exceptions.SSLError,
     ssl.SSLError,
     socket.gaierror,

--- a/services/workflow-api/app/run_artifacts.py
+++ b/services/workflow-api/app/run_artifacts.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from services.common.schemas import ArtifactIndexEntry, ArtifactsIndex, RunStatus
 
 from .config import Settings
-from .job_submission import JobSubmitter
+from .job_submission import JobSubmitter, LiveStatusUnavailableError
 from .schemas import LogEntry, RunRecord
 
 MEDIA_TYPES = {
@@ -183,11 +183,26 @@ def _path_is_within(path: Path, root: Path) -> bool:
 def resolve_run_status(record: RunRecord, settings: Settings, submitter: JobSubmitter) -> RunStatus:
     # Prefer on-disk terminal status first (authoritative once written), then
     # live Kubernetes status (for in-flight jobs), falling back to the stored
-    # record (accepted but not yet scheduled).
+    # record (accepted but not yet scheduled). A Kubernetes API/transport
+    # outage degrades to the stored record with an explicit note rather than
+    # surfacing an HTTP 500.
     disk_status = load_status_from_disk(settings, record.run_id)
     if disk_status is not None:
         return disk_status
-    live_status = submitter.get_live_status(record)
+    try:
+        live_status = submitter.get_live_status(record)
+    except LiveStatusUnavailableError as exc:
+        durable = record.status
+        durable_detail = f'{durable.detail}; ' if durable.detail else ''
+        return RunStatus(
+            run_id=record.run_id,
+            status=durable.status,
+            updated_at=durable.updated_at,
+            detail=(
+                f'{durable_detail}Live Kubernetes status unavailable '
+                f'({exc}); showing durable stored status.'
+            ),
+        )
     if live_status is not None:
         return live_status
     return record.status

--- a/services/workflow-api/app/run_artifacts.py
+++ b/services/workflow-api/app/run_artifacts.py
@@ -191,7 +191,7 @@ def resolve_run_status(record: RunRecord, settings: Settings, submitter: JobSubm
         return disk_status
     try:
         live_status = submitter.get_live_status(record)
-    except LiveStatusUnavailableError as exc:
+    except LiveStatusUnavailableError:
         durable = record.status
         durable_detail = f'{durable.detail}; ' if durable.detail else ''
         return RunStatus(
@@ -199,8 +199,8 @@ def resolve_run_status(record: RunRecord, settings: Settings, submitter: JobSubm
             status=durable.status,
             updated_at=durable.updated_at,
             detail=(
-                f'{durable_detail}Live Kubernetes status unavailable '
-                f'({exc}); showing durable stored status.'
+                f'{durable_detail}Live Kubernetes status unavailable; '
+                'showing durable stored status.'
             ),
         )
     if live_status is not None:

--- a/services/workflow-api/tests/test_api.py
+++ b/services/workflow-api/tests/test_api.py
@@ -25,6 +25,7 @@ from app.config import Settings
 import app.autoresearch as autoresearch_module
 import app.main as main_module
 import app.source_documents as source_documents
+from app.job_submission import LiveStatusUnavailableError, NullJobSubmitter
 from app.schemas import AutoresearchDecisionRecord, AutoresearchIterationRecord, EvaluatorContract
 from app.stage_interpretation import build_interpretation_record_from_agent_draft, validate_interpretation_agent_draft
 from app.main import create_app
@@ -6787,3 +6788,48 @@ def test_autoresearch_notebook_refinement_uses_coding_model_response(tmp_path, m
 
     path = Path(payload['storage_uri'].removeprefix('file://'))
     assert path.exists()
+
+
+def test_run_status_route_returns_200_during_kube_outage() -> None:
+    settings = Settings(
+        registry_dir=str(REPO_ROOT / 'services' / 'workflow-registry' / 'definitions'),
+    )
+    registry = WorkflowRegistry(settings.registry_dir)
+    store = InMemoryRunStore()
+
+    class OutageSubmitter(NullJobSubmitter):
+        def get_live_status(self, record):
+            raise LiveStatusUnavailableError(
+                'Kubernetes transport failure during live status lookup'
+            )
+
+    client = TestClient(
+        create_app(
+            settings=settings,
+            registry=registry,
+            store=store,
+            submitter=OutageSubmitter(namespace='default'),
+        )
+    )
+
+    create = client.post(
+        '/experiments/runs',
+        json={
+            'objective': 'Observe a run during a Kubernetes outage.',
+            'experiment_type': 'gpu-training-job',
+            'workload_id': 'metric-search-v0',
+            'entrypoint': ['python3', 'scripts/run_experiment.py'],
+            'config_payload': {'search_space_id': 'art-metric-baseline'},
+            'dataset_bindings': {'train_uri': 's3://datasets/art/train.parquet'},
+            'budget': {'max_epochs': 1, 'max_wallclock_minutes': 5},
+            'submitted_by': 'test-suite',
+        },
+    )
+    assert create.status_code == 201
+    run_id = create.json()['run_id']
+
+    got = client.get(f'/runs/{run_id}')
+    assert got.status_code == 200
+    status = got.json()['status']
+    assert 'Live Kubernetes status unavailable' in status['detail']
+    assert 'showing durable stored status' in status['detail']

--- a/services/workflow-api/tests/test_run_artifacts.py
+++ b/services/workflow-api/tests/test_run_artifacts.py
@@ -322,6 +322,15 @@ def test_get_live_status_maps_expected_exceptions_to_unavailable() -> None:
             'Connection refused',
         ),
         urllib3.exceptions.SSLError('TLS handshake failure'),
+        urllib3.exceptions.ConnectTimeoutError(
+            urllib3.connectionpool.HTTPConnectionPool(host='k8s', port=443),
+            'connection timed out',
+        ),
+        urllib3.exceptions.ReadTimeoutError(
+            urllib3.connectionpool.HTTPConnectionPool(host='k8s', port=443),
+            '/apis/batch/v1/namespaces/default/jobs/job',
+            'read timed out',
+        ),
     ]
 
     for exc in cases:

--- a/services/workflow-api/tests/test_run_artifacts.py
+++ b/services/workflow-api/tests/test_run_artifacts.py
@@ -8,7 +8,10 @@ complete terminal bundles, and rejecting symlink artifacts.
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 from app.config import Settings
+from app.job_submission import KubernetesJobSubmitter, LiveStatusUnavailableError
 from app.run_artifacts import (
     artifact_run_dir,
     build_artifacts_from_directory,
@@ -229,3 +232,118 @@ def test_terminal_bundle_rejects_symlink_artifact(tmp_path) -> None:
         assert 'report.md' in str(exc)
     else:
         raise AssertionError('symlink artifact must reject successful ingestion')
+
+
+class _UnavailableSubmitter:
+    def __init__(self, exc: Exception) -> None:
+        self.exc = exc
+
+    def get_live_status(self, record):
+        raise self.exc
+
+
+def _queued_record(run_id: str) -> RunRecord:
+    return build_run_record(
+        run_id,
+        RunStatus(
+            run_id=run_id,
+            status='queued',
+            updated_at=datetime(2026, 3, 26, 11, 59, tzinfo=timezone.utc),
+            detail='accepted, awaiting scheduling',
+        ),
+    )
+
+
+def test_resolve_run_status_degrades_on_live_status_unavailable(tmp_path) -> None:
+    settings = build_settings(tmp_path)
+    record = _queued_record('run-degrade')
+    submitter = _UnavailableSubmitter(
+        LiveStatusUnavailableError('Kubernetes API error during live status lookup')
+    )
+
+    resolved = resolve_run_status(record, settings, submitter)
+
+    assert resolved.status == 'queued'
+    assert resolved.run_id == 'run-degrade'
+    assert 'accepted, awaiting scheduling' in resolved.detail
+    assert 'Live Kubernetes status unavailable' in resolved.detail
+    assert 'showing durable stored status' in resolved.detail
+
+
+def test_resolve_run_status_unexpected_exception_propagates(tmp_path) -> None:
+    settings = build_settings(tmp_path)
+    record = _queued_record('run-program-error')
+    submitter = _UnavailableSubmitter(RuntimeError('unexpected bug'))
+
+    with pytest.raises(RuntimeError):
+        resolve_run_status(record, settings, submitter)
+
+
+def test_resolve_run_status_disk_terminal_authoritative_during_outage(tmp_path) -> None:
+    settings = build_settings(tmp_path)
+    run_id = 'run-disk-authoritative'
+    run_dir = artifact_run_dir(settings, run_id)
+    run_dir.mkdir(parents=True)
+    (run_dir / 'status.json').write_text(
+        '{"run_id":"run-disk-authoritative","status":"succeeded",'
+        '"updated_at":"2026-03-26T12:00:00Z","detail":"done"}'
+    )
+    record = _queued_record(run_id)
+    submitter = _UnavailableSubmitter(
+        LiveStatusUnavailableError('Kubernetes transport failure during live status lookup')
+    )
+
+    resolved = resolve_run_status(record, settings, submitter)
+
+    assert resolved.status == 'succeeded'
+    assert 'Live Kubernetes status unavailable' not in (resolved.detail or '')
+
+
+def test_get_live_status_maps_expected_exceptions_to_unavailable() -> None:
+    import socket
+    import ssl
+    import urllib3
+    from kubernetes.client.exceptions import ApiException
+
+    submitter = KubernetesJobSubmitter.__new__(KubernetesJobSubmitter)
+    submitter.api_exception = ApiException
+    record = _queued_record('run-live-status')
+
+    cases = [
+        ApiException(status=503, reason='Service Unavailable'),
+        socket.gaierror('Name or service not known'),
+        ssl.SSLError(1, 'TLS handshake failure'),
+        urllib3.exceptions.MaxRetryError(
+            urllib3.connectionpool.HTTPConnectionPool(host='k8s', port=443),
+            '/apis/batch/v1/namespaces/default/jobs/job',
+        ),
+        urllib3.exceptions.NewConnectionError(
+            urllib3.connectionpool.HTTPConnectionPool(host='k8s', port=443),
+            'Connection refused',
+        ),
+        urllib3.exceptions.SSLError('TLS handshake failure'),
+    ]
+
+    for exc in cases:
+        class _FailingBatchApi:
+            def read_namespaced_job(self, **kwargs):
+                raise exc
+
+        submitter.batch_api = _FailingBatchApi()
+        with pytest.raises(LiveStatusUnavailableError):
+            submitter.get_live_status(record)
+
+
+def test_get_live_status_lets_programming_errors_propagate() -> None:
+    from kubernetes.client.exceptions import ApiException
+
+    submitter = KubernetesJobSubmitter.__new__(KubernetesJobSubmitter)
+    submitter.api_exception = ApiException
+
+    class _ExplodingBatchApi:
+        def read_namespaced_job(self, **kwargs):
+            raise RuntimeError('unexpected bug')
+
+    submitter.batch_api = _ExplodingBatchApi()
+    with pytest.raises(RuntimeError):
+        submitter.get_live_status(_queued_record('run-live-program-error'))


### PR DESCRIPTION
Closes #121.

## What changed

`KubernetesJobSubmitter.get_live_status` previously swallowed only `ApiException` (returning `None`), but DNS, connection, and TLS transport failures escaped and surfaced as HTTP 500. Now expected infrastructure failures raise a typed `LiveStatusUnavailableError`, and `resolve_run_status` catches it to return the durable stored status with an explicit degradation note.

## Exact exception classes handled

| Category | Classes | Why expected |
|----------|---------|--------------|
| Kubernetes API | `kubernetes.client.exceptions.ApiException` | HTTP/API errors (e.g. 503, 404 during an API outage). Pre-existing behavior, now raised as typed. |
| DNS / connection | `urllib3.exceptions.MaxRetryError`, `urllib3.exceptions.NewConnectionError`, `urllib3.exceptions.ConnectionError`, `socket.gaierror` | The Kubernetes client uses urllib3; these are what it raises when the API server is unreachable (DNS failure, connection refused, timeouts). |
| TLS/SSL | `urllib3.exceptions.SSLError`, `ssl.SSLError` | TLS handshake / certificate failures against the API server; `ssl.SSLError` covers the raw case that can escape urllib3's wrapping. |

Not caught (must propagate): arbitrary `RuntimeError`, `ValueError`, etc. A deliberately raised `RuntimeError` is covered by a test.

## Behavior

- Live status lookup fails (expected outage) → return the durable stored `record.status`, with `RunStatus.detail` set to `"Live Kubernetes status unavailable (<reason>); showing durable stored status."` (the durable detail is preserved and prepended).
- On-disk terminal status remains authoritative: it is checked before the live lookup, so a completed run's `status.json` still wins during an outage.
- No change to `submit_run`, approvals, persistence, manifests, or deployment.

## Test commands and results

```
python3 -m py_compile services/workflow-api/app/job_submission.py services/workflow-api/app/run_artifacts.py
# OK

cd services/workflow-api
.venv314/bin/python -m pytest tests/ -q
# 165 passed
```

Tests added cover: API error → durable status; DNS/connection failure → durable status; TLS failure → durable status; degraded response is visibly identified; on-disk terminal status stays authoritative during an outage; unexpected `RuntimeError` still propagates; and the `/runs/{run_id}` route returns 200 during a simulated outage.

Note: `./scripts/check-before-push.sh --python-core` reports `invalid syntax` only inside `.venv314` site-packages (Python 3.14 packages vs system Python 3.9) — pre-existing and unrelated to this change; the changed files compile cleanly.