### PR TITLE
feat: add /research-status and /research-list Discord commands

### DIFF
--- a/docs/research-orchestrator-command-surface.md
+++ b/docs/research-orchestrator-command-surface.md
@@ -22,12 +22,17 @@ and approval role or explicit administrator allowlist.
 | `/research-pause [run_id:<id>] [reason:<text>]` | Run thread, or main channel with `run_id` | Aborts an active model turn, preserves state, and records where to resume. |
 | `/research-resume [run_id:<id>] [reason:<text>]` | Run thread, or main channel with `run_id` | Restores a paused run to its prior state and restarts workflow recovery. |
 | `/research-cancel [run_id:<id>] [reason:<text>]` | Run thread, or main channel with `run_id` | Cancels the run, aborts active Hermes turns, requests cancellation of active jobs, and records the Discord actor and reason. |
+| `/research-status [run_id:<id>]` | Run thread, or main channel with `run_id` | Shows a durable-derived snapshot of the run: state, phase, pending approval, job counts by status, and next required action. |
+| `/research-list` | Main Glasslab channel | Lists active runs first, then the most recently updated terminal runs, up to 10 total. |
 
-Inside a run thread, pause, resume, and cancel resolve the run from the thread
-and do not require an ID.
+Inside a run thread, pause, resume, cancel, and status resolve the run from the
+thread and do not require an ID. `/research-status` without a `run_id` in the
+main channel is rejected; `/research-list` takes no arguments.
 
-Discord does not currently expose list or status slash commands. Status is
-shown by the run thread's editable status message.
+`/research-status` and `/research-list` are read-only projections: they derive
+their output only from durable run, action, and job records and never mutate
+state, append events, create actions, or trigger recovery. Pending human
+approval takes precedence when deriving the "next action" field.
 
 ## Intended End-To-End Run
 

--- a/services/research-orchestrator/app/discord_controls.py
+++ b/services/research-orchestrator/app/discord_controls.py
@@ -195,12 +195,13 @@ def select_runs_for_list(
     limit: int = RUN_LIST_LIMIT,
 ) -> list[RunRecord]:
     # Active runs first, then the most recently updated terminal runs, capped at
-    # `limit`. Both halves are ordered by updated_at (newest first) so the
-    # result is deterministic regardless of the store's creation order.
+    # `limit`. Both halves are ordered by updated_at (newest first); run_id is a
+    # stable tie-breaker so equal timestamps still produce a deterministic order
+    # regardless of the store's creation order.
     active = [run for run in runs if run.state not in TERMINAL_STATES]
     terminal = [run for run in runs if run.state in TERMINAL_STATES]
-    active.sort(key=lambda run: run.updated_at, reverse=True)
-    terminal.sort(key=lambda run: run.updated_at, reverse=True)
+    active.sort(key=lambda run: (run.updated_at, run.run_id), reverse=True)
+    terminal.sort(key=lambda run: (run.updated_at, run.run_id), reverse=True)
     return (active + terminal)[:limit]
 
 

--- a/services/research-orchestrator/app/discord_controls.py
+++ b/services/research-orchestrator/app/discord_controls.py
@@ -100,14 +100,10 @@ _NEXT_ACTION_BY_STATE = {
     RunState.HONEYDEW_WRITING_REPORT: 'Honeydew is writing the report',
 }
 
-# Statuses whose counts are always rendered in a fixed order.
-_RENDERED_JOB_STATUSES = (
-    JobStatus.QUEUED,
-    JobStatus.RUNNING,
-    JobStatus.SUCCEEDED,
-    JobStatus.FAILED,
-    JobStatus.CANCELLED,
-)
+# Statuses whose counts are always rendered in a fixed order. Every JobStatus
+# is included so queued/running/succeeded/failed/cancelled/submitting/unknown
+# jobs are never silently omitted from the projection.
+_RENDERED_JOB_STATUSES = tuple(JobStatus)
 
 
 @dataclass(frozen=True)
@@ -124,14 +120,19 @@ class RunStatusView:
 
 def pending_human_approval(actions: list[ActionRecord]) -> ActionRecord | None:
     # Only actions that still require a human decision are "next action" worthy.
-    # HONEYDEW_AND_HUMAN_APPROVAL counts because the human gate is still open.
+    # A combined HONEYDEW_AND_HUMAN_APPROVAL gate is not human-ready until
+    # Honeydew has signed off (honeydew_approved); before that, the next action
+    # is derived from the current Honeydew-review state instead.
     for action in actions:
         if action.approval_status != ApprovalStatus.PENDING:
             continue
-        if action.policy_classification in {
-            PolicyClassification.HUMAN_APPROVAL,
-            PolicyClassification.HONEYDEW_AND_HUMAN_APPROVAL,
-        }:
+        if action.policy_classification == PolicyClassification.HUMAN_APPROVAL:
+            return action
+        if (
+            action.policy_classification
+            == PolicyClassification.HONEYDEW_AND_HUMAN_APPROVAL
+            and action.honeydew_approved
+        ):
             return action
     return None
 
@@ -1169,20 +1170,36 @@ class DiscordControlGateway:
             )
             return
         try:
-            run = self._resolve_controlled_run(
+            run, actions, jobs = await asyncio.to_thread(
+                self._load_run_status,
                 channel_id=str(interaction.channel_id),
                 run_id=run_id,
             )
         except Exception as exc:
             await self._respond(interaction, f'Status lookup failed: {exc}')
             return
-        actions = self.engine.store.list_actions(run.run_id)
-        jobs = self.engine.store.list_jobs(run.run_id)
         view = build_run_status_view(run, actions, jobs)
         await self._respond(
             interaction,
             bound_discord_message(render_run_status(view)),
         )
+
+    def _load_run_status(
+        self,
+        *,
+        channel_id: str,
+        run_id: str | None,
+    ) -> tuple[RunRecord, list[ActionRecord], list[JobRecord]]:
+        # Synchronous, disk/DB-bound reads run in a worker thread so the
+        # gateway event loop stays responsive; resolution is re-checked against
+        # the durable store at this point, never trusted from Discord.
+        run = self._resolve_controlled_run(
+            channel_id=channel_id,
+            run_id=run_id,
+        )
+        actions = self.engine.store.list_actions(run.run_id)
+        jobs = self.engine.store.list_jobs(run.run_id)
+        return run, actions, jobs
 
     async def _on_research_list(self, interaction: discord.Interaction) -> None:
         actor = self._actor(interaction)
@@ -1192,7 +1209,17 @@ class DiscordControlGateway:
                 'You are not authorized to list Glasslab research runs.',
             )
             return
-        runs = self.engine.store.list_runs()
+        if str(interaction.channel_id) != self.channel_id:
+            await self._respond(
+                interaction,
+                'List research runs from the configured Glasslab channel.',
+            )
+            return
+        try:
+            runs = await asyncio.to_thread(self.engine.store.list_runs)
+        except Exception as exc:
+            await self._respond(interaction, f'Run list failed: {exc}')
+            return
         await self._respond(
             interaction,
             bound_discord_message(render_run_list(select_runs_for_list(runs))),

--- a/services/research-orchestrator/app/discord_controls.py
+++ b/services/research-orchestrator/app/discord_controls.py
@@ -619,24 +619,6 @@ class DiscordControlGateway:
                 limit=int(limit),
             )
 
-        )
-        async def research_status(
-            interaction: discord.Interaction,
-            run_id: str | None = None,
-        ) -> None:
-            await self._on_research_status(
-                interaction,
-                run_id=run_id,
-            )
-
-        @self.tree.command(
-            name='research-list',
-            description='List active and recent Glasslab research runs.',
-            guild=self.guild,
-        )
-        async def research_list(interaction: discord.Interaction) -> None:
-            await self._on_research_list(interaction)
-
         @self.tree.command(
             name='research-status',
             description='Show the durable status of a Glasslab research run.',

--- a/services/research-orchestrator/app/discord_controls.py
+++ b/services/research-orchestrator/app/discord_controls.py
@@ -19,10 +19,16 @@ from discord import app_commands
 
 from .artifact_delivery import ArtifactBundle, build_run_artifact_bundle
 from .schemas import (
+    ActionRecord,
     ApprovalStatus,
     IngestedDatasetRecord,
+    JobRecord,
+    JobStatus,
+    PolicyClassification,
     RunCreateRequest,
     RunRecord,
+    RunState,
+    TERMINAL_STATES,
 )
 from .turn_inspection import (
     DEFAULT_DISCORD_TURN_LIMIT,
@@ -36,6 +42,184 @@ if TYPE_CHECKING:
 
 
 CONTROL_PREFIX = 'glasslab'
+
+RUN_LIST_LIMIT = 10
+DISCORD_MESSAGE_LIMIT = 2000
+
+# Action types that represent a pending human approval in the workflow. The
+# mapped value is the instruction shown to the operator as the next action.
+_PENDING_APPROVAL_ACTIONS = {
+    'approve_protocol': 'approve the proposed protocol',
+    'propose_evaluation_contract': 'approve evaluation-contract promotion',
+    'submit_experiment_matrix': 'approve cluster execution',
+    'accept_final_report': 'accept the final report',
+}
+
+_PHASE_LABELS = {
+    RunState.CREATED: 'created',
+    RunState.PREPARING: 'preparing',
+    RunState.HONEYDEW_DRAFTING_PROTOCOL: 'drafting protocol',
+    RunState.AWAITING_PROTOCOL_APPROVAL: 'awaiting protocol approval',
+    RunState.BEAKER_DRAFTING_CONTRACT: 'drafting evaluation contract',
+    RunState.HONEYDEW_REVIEWING_CONTRACT: 'reviewing contract candidate',
+    RunState.AWAITING_CONTRACT_PROMOTION: 'awaiting contract promotion',
+    RunState.BEAKER_PLANNING: 'planning implementation',
+    RunState.BEAKER_IMPLEMENTING: 'implementing workload',
+    RunState.BEAKER_FINALIZING: 'finalizing workload',
+    RunState.HONEYDEW_REVIEWING: 'honeydew reviewing implementation',
+    RunState.BEAKER_REVISING: 'revising implementation',
+    RunState.AWAITING_EXECUTION_APPROVAL: 'awaiting execution approval',
+    RunState.JOB_QUEUED: 'jobs queued',
+    RunState.JOB_RUNNING: 'jobs running',
+    RunState.BEAKER_ANALYZING: 'analyzing results',
+    RunState.HONEYDEW_VERIFYING: 'verifying results',
+    RunState.HONEYDEW_WRITING_REPORT: 'writing report',
+    RunState.AWAITING_FINAL_ACCEPTANCE: 'awaiting final acceptance',
+    RunState.COMPLETE: 'complete',
+    RunState.PAUSED: 'paused',
+    RunState.FAILED: 'failed',
+    RunState.CANCELLED: 'cancelled',
+    RunState.TIMED_OUT: 'timed out',
+}
+
+_NEXT_ACTION_BY_STATE = {
+    RunState.CREATED: 'orchestrator is preparing the run',
+    RunState.PREPARING: 'orchestrator is preparing workspaces',
+    RunState.HONEYDEW_DRAFTING_PROTOCOL: 'Honeydew is drafting the protocol',
+    RunState.BEAKER_DRAFTING_CONTRACT: 'Beaker is drafting the contract candidate',
+    RunState.HONEYDEW_REVIEWING_CONTRACT: 'Honeydew is reviewing the contract candidate',
+    RunState.BEAKER_PLANNING: 'Beaker is planning the implementation',
+    RunState.BEAKER_IMPLEMENTING: 'Beaker is implementing the workload',
+    RunState.BEAKER_FINALIZING: 'Beaker is finalizing the workload',
+    RunState.HONEYDEW_REVIEWING: 'Honeydew is reviewing the implementation',
+    RunState.BEAKER_REVISING: 'Beaker is revising the implementation',
+    RunState.JOB_QUEUED: 'waiting for cluster jobs to run',
+    RunState.JOB_RUNNING: 'cluster jobs are running',
+    RunState.BEAKER_ANALYZING: 'Beaker is analyzing results',
+    RunState.HONEYDEW_VERIFYING: 'Honeydew is verifying results',
+    RunState.HONEYDEW_WRITING_REPORT: 'Honeydew is writing the report',
+}
+
+# Statuses whose counts are always rendered in a fixed order.
+_RENDERED_JOB_STATUSES = (
+    JobStatus.QUEUED,
+    JobStatus.RUNNING,
+    JobStatus.SUCCEEDED,
+    JobStatus.FAILED,
+    JobStatus.CANCELLED,
+)
+
+
+@dataclass(frozen=True)
+class RunStatusView:
+    """Durable-derived status snapshot for a single run."""
+
+    run_id: str
+    state: str
+    phase: str
+    pending_approval: str | None
+    job_counts: dict[str, int]
+    next_action: str
+
+
+def pending_human_approval(actions: list[ActionRecord]) -> ActionRecord | None:
+    # Only actions that still require a human decision are "next action" worthy.
+    # HONEYDEW_AND_HUMAN_APPROVAL counts because the human gate is still open.
+    for action in actions:
+        if action.approval_status != ApprovalStatus.PENDING:
+            continue
+        if action.policy_classification in {
+            PolicyClassification.HUMAN_APPROVAL,
+            PolicyClassification.HONEYDEW_AND_HUMAN_APPROVAL,
+        }:
+            return action
+    return None
+
+
+def job_status_counts(jobs: list[JobRecord]) -> dict[str, int]:
+    counts = {status.value: 0 for status in _RENDERED_JOB_STATUSES}
+    for job in jobs:
+        if job.status.value in counts:
+            counts[job.status.value] += 1
+    return counts
+
+
+def next_action_for(run: RunRecord, actions: list[ActionRecord]) -> str:
+    pending = pending_human_approval(actions)
+    if pending is not None:
+        return _PENDING_APPROVAL_ACTIONS.get(
+            pending.type,
+            f'resolve pending {pending.type}',
+        )
+    if run.state in TERMINAL_STATES:
+        return f'no action; run is {run.state.value.lower()}'
+    if run.state == RunState.PAUSED:
+        return 'resume the paused run'
+    return _NEXT_ACTION_BY_STATE.get(run.state, f'progress through {run.state.value}')
+
+
+def build_run_status_view(
+    run: RunRecord,
+    actions: list[ActionRecord],
+    jobs: list[JobRecord],
+) -> RunStatusView:
+    pending = pending_human_approval(actions)
+    return RunStatusView(
+        run_id=run.run_id,
+        state=run.state.value,
+        phase=_PHASE_LABELS.get(run.state, run.state.value),
+        pending_approval=pending.type if pending is not None else None,
+        job_counts=job_status_counts(jobs),
+        next_action=next_action_for(run, actions),
+    )
+
+
+def render_run_status(view: RunStatusView) -> str:
+    jobs = ', '.join(
+        f'{status} {view.job_counts[status]}'
+        for status in (s.value for s in _RENDERED_JOB_STATUSES)
+    )
+    lines = [
+        f'Research run `{view.run_id}`',
+        f'State: {view.state} ({view.phase})',
+        f'Pending approval: {view.pending_approval or "none"}',
+        f'Jobs: {jobs}',
+        f'Next action: {view.next_action}',
+    ]
+    return '\n'.join(lines)
+
+
+def select_runs_for_list(
+    runs: list[RunRecord],
+    *,
+    limit: int = RUN_LIST_LIMIT,
+) -> list[RunRecord]:
+    # Active runs first, then the most recently updated terminal runs, capped at
+    # `limit`. Both halves are ordered by updated_at (newest first) so the
+    # result is deterministic regardless of the store's creation order.
+    active = [run for run in runs if run.state not in TERMINAL_STATES]
+    terminal = [run for run in runs if run.state in TERMINAL_STATES]
+    active.sort(key=lambda run: run.updated_at, reverse=True)
+    terminal.sort(key=lambda run: run.updated_at, reverse=True)
+    return (active + terminal)[:limit]
+
+
+def render_run_list(runs: list[RunRecord]) -> str:
+    if not runs:
+        return 'No Glasslab research runs.'
+    lines = ['Glasslab research runs:']
+    for run in runs:
+        state = run.state.value
+        if run.state in TERMINAL_STATES:
+            state = f'{state} (terminal)'
+        lines.append(f'- `{run.run_id}` — {state}')
+    return '\n'.join(lines)
+
+
+def bound_discord_message(text: str, limit: int = DISCORD_MESSAGE_LIMIT) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + '...'
 
 
 @dataclass(frozen=True)
@@ -433,6 +617,45 @@ class DiscordControlGateway:
                 limit=int(limit),
             )
 
+        )
+        async def research_status(
+            interaction: discord.Interaction,
+            run_id: str | None = None,
+        ) -> None:
+            await self._on_research_status(
+                interaction,
+                run_id=run_id,
+            )
+
+        @self.tree.command(
+            name='research-list',
+            description='List active and recent Glasslab research runs.',
+            guild=self.guild,
+        )
+        async def research_list(interaction: discord.Interaction) -> None:
+            await self._on_research_list(interaction)
+
+        @self.tree.command(
+            name='research-status',
+            description='Show the durable status of a Glasslab research run.',
+            guild=self.guild,
+        )
+        @app_commands.describe(
+            run_id='Optional in a run thread; required from the main channel.',
+        )
+        async def research_status(
+            interaction: discord.Interaction,
+            run_id: str | None = None,
+        ) -> None:
+            await self._on_research_status(interaction, run_id=run_id)
+
+        @self.tree.command(
+            name='research-list',
+            description='List active and recent Glasslab research runs.',
+            guild=self.guild,
+        )
+        async def research_list(interaction: discord.Interaction) -> None:
+            await self._on_research_list(interaction)
     def _register_run_control_command(self, operation: str) -> None:
         async def callback(
             interaction: discord.Interaction,
@@ -930,6 +1153,49 @@ class DiscordControlGateway:
                 interaction,
                 f'Run cancellation failed: {exc}',
             )
+
+    async def _on_research_status(
+        self,
+        interaction: discord.Interaction,
+        *,
+        run_id: str | None,
+    ) -> None:
+        actor = self._actor(interaction)
+        if not self.policy.is_authorized(actor):
+            await self._respond(
+                interaction,
+                'You are not authorized to inspect Glasslab research runs.',
+            )
+            return
+        try:
+            run = self._resolve_controlled_run(
+                channel_id=str(interaction.channel_id),
+                run_id=run_id,
+            )
+        except Exception as exc:
+            await self._respond(interaction, f'Status lookup failed: {exc}')
+            return
+        actions = self.engine.store.list_actions(run.run_id)
+        jobs = self.engine.store.list_jobs(run.run_id)
+        view = build_run_status_view(run, actions, jobs)
+        await self._respond(
+            interaction,
+            bound_discord_message(render_run_status(view)),
+        )
+
+    async def _on_research_list(self, interaction: discord.Interaction) -> None:
+        actor = self._actor(interaction)
+        if not self.policy.is_authorized(actor):
+            await self._respond(
+                interaction,
+                'You are not authorized to list Glasslab research runs.',
+            )
+            return
+        runs = self.engine.store.list_runs()
+        await self._respond(
+            interaction,
+            bound_discord_message(render_run_list(select_runs_for_list(runs))),
+        )
 
     async def _on_interaction(
         self,

--- a/services/research-orchestrator/tests/test_discord_and_opencode.py
+++ b/services/research-orchestrator/tests/test_discord_and_opencode.py
@@ -1489,6 +1489,24 @@ def test_run_list_caps_at_ten() -> None:
     assert len(selected) == 10
 
 
+def test_run_list_uses_stable_tie_breaker() -> None:
+    ts = datetime(2026, 3, 1, tzinfo=timezone.utc)
+    runs = [
+        _run(run_id='run-b', state=RunState.JOB_RUNNING, updated_at=ts),
+        _run(run_id='run-a', state=RunState.JOB_RUNNING, updated_at=ts),
+        _run(run_id='run-c', state=RunState.JOB_RUNNING, updated_at=ts),
+    ]
+
+    forward = select_runs_for_list(runs)
+    reversed_ = select_runs_for_list(list(reversed(runs)))
+
+    # Equal updated_at must order identically regardless of input order.
+    assert [run.run_id for run in forward] == [
+        run.run_id for run in reversed_
+    ]
+    assert len(set(run.run_id for run in forward)) == 3
+
+
 def test_render_run_status_includes_durable_fields() -> None:
     run = _run(run_id='run-1', state=RunState.AWAITING_EXECUTION_APPROVAL)
     actions = [

--- a/services/research-orchestrator/tests/test_discord_and_opencode.py
+++ b/services/research-orchestrator/tests/test_discord_and_opencode.py
@@ -1275,11 +1275,13 @@ def _action(
     type_: str,
     classification: PolicyClassification,
     status: ApprovalStatus = ApprovalStatus.PENDING,
+    honeydew_approved: bool = False,
 ):
     return SimpleNamespace(
         type=type_,
         policy_classification=classification,
         approval_status=status,
+        honeydew_approved=honeydew_approved,
     )
 
 
@@ -1423,30 +1425,61 @@ def test_next_action_prefers_pending_approval(
     action_type, classification, expected,
 ) -> None:
     run = _run(run_id='run-1', state=RunState.AWAITING_PROTOCOL_APPROVAL)
-    actions = [_action(type_=action_type, classification=classification)]
+    actions = [
+        _action(
+            type_=action_type,
+            classification=classification,
+            honeydew_approved=(
+                classification
+                == PolicyClassification.HONEYDEW_AND_HUMAN_APPROVAL
+            ),
+        )
+    ]
 
     assert next_action_for(run, actions) == expected
+
+
+def test_pending_human_approval_requires_honeydew_gate() -> None:
+    # A combined gate is not human-ready until Honeydew has signed off; before
+    # that, the next action is derived from the Honeydew-review state.
+    run = _run(run_id='run-1', state=RunState.HONEYDEW_REVIEWING)
+    actions = [
+        _action(
+            type_='submit_experiment_matrix',
+            classification=PolicyClassification.HONEYDEW_AND_HUMAN_APPROVAL,
+            honeydew_approved=False,
+        ),
+    ]
+
+    assert pending_human_approval(actions) is None
+    assert next_action_for(run, actions) == (
+        'Honeydew is reviewing the implementation'
+    )
 
 
 def test_job_status_counts_across_states() -> None:
     jobs = [
         _job(JobStatus.QUEUED),
         _job(JobStatus.QUEUED),
+        _job(JobStatus.SUBMITTING),
         _job(JobStatus.RUNNING),
         _job(JobStatus.SUCCEEDED),
         _job(JobStatus.SUCCEEDED),
         _job(JobStatus.SUCCEEDED),
         _job(JobStatus.FAILED),
+        _job(JobStatus.UNKNOWN),
     ]
 
     counts = job_status_counts(jobs)
 
     assert counts == {
         'queued': 2,
+        'submitting': 1,
         'running': 1,
         'succeeded': 3,
         'failed': 1,
         'cancelled': 0,
+        'unknown': 1,
     }
 
 
@@ -1513,6 +1546,7 @@ def test_render_run_status_includes_durable_fields() -> None:
         _action(
             type_='submit_experiment_matrix',
             classification=PolicyClassification.HONEYDEW_AND_HUMAN_APPROVAL,
+            honeydew_approved=True,
         ),
     ]
     jobs = [_job(JobStatus.SUCCEEDED), _job(JobStatus.RUNNING)]

--- a/services/research-orchestrator/tests/test_discord_and_opencode.py
+++ b/services/research-orchestrator/tests/test_discord_and_opencode.py
@@ -8,6 +8,7 @@ repair, workspace-file materialization, and per-agent runtime isolation.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import json
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -19,15 +20,24 @@ import pytest
 from app.discord_adapter import DiscordHttpAdapter, DiscordRenderer
 from app.config import Settings
 from app.discord_controls import (
+    DISCORD_MESSAGE_LIMIT,
     DiscordControlActor,
     DiscordControlGateway,
     DiscordControlPolicy,
+    bound_discord_message,
+    build_run_status_view,
     execute_discord_action,
     execute_discord_dataset_ingestion,
     execute_discord_run_control,
     execute_discord_run_cancellation,
     execute_discord_run_creation,
     execute_discord_turn_history,
+    job_status_counts,
+    next_action_for,
+    pending_human_approval,
+    render_run_list,
+    render_run_status,
+    select_runs_for_list,
 )
 from app.opencode_runtime import (
     OpenCodeProcessRuntime,
@@ -47,6 +57,11 @@ from app.schemas import (
     TurnKind,
     TurnRecord,
     utc_now,
+    ApprovalStatus,
+    JobStatus,
+    PolicyClassification,
+    RunState,
+    TERMINAL_STATES,
 )
 
 
@@ -386,6 +401,8 @@ def test_discord_gateway_registers_component_handler() -> None:
         'research-artifacts',
         'research-turns',
         'dataset-upload',
+        'research-status',
+        'research-list',
     ):
         assert gateway.tree.get_command(
             command_name,
@@ -1231,3 +1248,286 @@ def test_opencode_repairs_missing_structured_output(
     assert 'Return only the structured result' in (
         repair_payload['parts'][0]['text']
     )
+
+
+# ------------------------------------------------------------------ #
+# /research-status and /research-list pure rendering and resolution
+# ------------------------------------------------------------------ #
+
+
+def _run(
+    *,
+    run_id: str,
+    state: RunState,
+    updated_at: datetime | None = None,
+    thread_id: str | None = None,
+):
+    return SimpleNamespace(
+        run_id=run_id,
+        state=state,
+        updated_at=updated_at or datetime(2026, 1, 1, tzinfo=timezone.utc),
+        discord_thread_id=thread_id,
+    )
+
+
+def _action(
+    *,
+    type_: str,
+    classification: PolicyClassification,
+    status: ApprovalStatus = ApprovalStatus.PENDING,
+):
+    return SimpleNamespace(
+        type=type_,
+        policy_classification=classification,
+        approval_status=status,
+    )
+
+
+def _job(status: JobStatus):
+    return SimpleNamespace(status=status)
+
+
+def _gateway(runs) -> DiscordControlGateway:
+    store = Mock()
+    store.list_runs.return_value = list(runs)
+
+    def get_run(run_id: str):
+        for run in runs:
+            if run.run_id == run_id:
+                return run
+        raise KeyError(run_id)
+
+    store.get_run.side_effect = get_run
+    engine = Mock()
+    engine.store = store
+    return DiscordControlGateway(
+        engine=engine,
+        bot_token='bot-token',
+        guild_id='123456789',
+        channel_id='main-channel',
+        admin_role_id='role-1',
+        admin_user_ids=[],
+        maximum_dataset_upload_bytes=1024,
+    )
+
+
+def test_status_resolves_run_from_thread_without_run_id() -> None:
+    run = _run(run_id='run-1', state=RunState.AWAITING_PROTOCOL_APPROVAL,
+               thread_id='thread-1')
+    gateway = _gateway([run])
+
+    resolved = gateway._resolve_controlled_run(
+        channel_id='thread-1',
+        run_id=None,
+    )
+
+    assert resolved.run_id == 'run-1'
+
+
+def test_status_requires_run_id_outside_thread() -> None:
+    gateway = _gateway([_run(run_id='run-1', state=RunState.COMPLETE,
+                             thread_id='thread-1')])
+
+    with pytest.raises(ValueError, match='run_id is required'):
+        gateway._resolve_controlled_run(
+            channel_id='main-channel',
+            run_id=None,
+        )
+
+
+def test_status_rejects_unknown_run_id() -> None:
+    gateway = _gateway([_run(run_id='run-1', state=RunState.COMPLETE,
+                             thread_id='thread-1')])
+
+    with pytest.raises(KeyError):
+        gateway._resolve_controlled_run(
+            channel_id='main-channel',
+            run_id='run-missing',
+        )
+
+
+def test_status_rejects_mismatched_thread_and_run() -> None:
+    gateway = _gateway([
+        _run(run_id='run-1', state=RunState.COMPLETE, thread_id='thread-1'),
+        _run(run_id='run-2', state=RunState.JOB_RUNNING, thread_id='thread-2'),
+    ])
+
+    with pytest.raises(ValueError, match='control the run from'):
+        gateway._resolve_controlled_run(
+            channel_id='thread-1',
+            run_id='run-2',
+        )
+
+
+def test_status_rejects_unsupported_channel() -> None:
+    gateway = _gateway([_run(run_id='run-1', state=RunState.COMPLETE,
+                             thread_id='thread-1')])
+
+    with pytest.raises(ValueError, match='control the run from'):
+        gateway._resolve_controlled_run(
+            channel_id='other-channel',
+            run_id='run-1',
+        )
+
+
+def test_pending_human_approval_precedes_automatic_actions() -> None:
+    actions = [
+        _action(
+            type_='read_workspace',
+            classification=PolicyClassification.AUTOMATIC,
+        ),
+        _action(
+            type_='approve_protocol',
+            classification=PolicyClassification.HUMAN_APPROVAL,
+        ),
+    ]
+
+    pending = pending_human_approval(actions)
+
+    assert pending is not None
+    assert pending.type == 'approve_protocol'
+
+
+def test_pending_human_approval_ignores_non_pending_and_agent_gates() -> None:
+    actions = [
+        _action(
+            type_='submit_validation_job',
+            classification=PolicyClassification.HONEYDEW_APPROVAL,
+        ),
+        _action(
+            type_='approve_protocol',
+            classification=PolicyClassification.HUMAN_APPROVAL,
+            status=ApprovalStatus.APPROVED,
+        ),
+    ]
+
+    assert pending_human_approval(actions) is None
+
+
+@pytest.mark.parametrize(
+    ('action_type', 'classification', 'expected'),
+    [
+        ('approve_protocol', PolicyClassification.HUMAN_APPROVAL,
+         'approve the proposed protocol'),
+        ('propose_evaluation_contract',
+         PolicyClassification.HONEYDEW_AND_HUMAN_APPROVAL,
+         'approve evaluation-contract promotion'),
+        ('submit_experiment_matrix',
+         PolicyClassification.HONEYDEW_AND_HUMAN_APPROVAL,
+         'approve cluster execution'),
+        ('accept_final_report', PolicyClassification.HUMAN_APPROVAL,
+         'accept the final report'),
+    ],
+)
+def test_next_action_prefers_pending_approval(
+    action_type, classification, expected,
+) -> None:
+    run = _run(run_id='run-1', state=RunState.AWAITING_PROTOCOL_APPROVAL)
+    actions = [_action(type_=action_type, classification=classification)]
+
+    assert next_action_for(run, actions) == expected
+
+
+def test_job_status_counts_across_states() -> None:
+    jobs = [
+        _job(JobStatus.QUEUED),
+        _job(JobStatus.QUEUED),
+        _job(JobStatus.RUNNING),
+        _job(JobStatus.SUCCEEDED),
+        _job(JobStatus.SUCCEEDED),
+        _job(JobStatus.SUCCEEDED),
+        _job(JobStatus.FAILED),
+    ]
+
+    counts = job_status_counts(jobs)
+
+    assert counts == {
+        'queued': 2,
+        'running': 1,
+        'succeeded': 3,
+        'failed': 1,
+        'cancelled': 0,
+    }
+
+
+def test_terminal_run_has_no_pending_action() -> None:
+    run = _run(run_id='run-1', state=RunState.COMPLETE)
+    assert next_action_for(run, []) == 'no action; run is complete'
+
+
+def test_run_list_active_first_then_recent_terminal() -> None:
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    runs = [
+        _run(run_id='old-terminal', state=RunState.COMPLETE,
+             updated_at=now),
+        _run(run_id='active-old', state=RunState.JOB_RUNNING,
+             updated_at=now),
+        _run(run_id='active-new', state=RunState.JOB_RUNNING,
+             updated_at=datetime(2026, 2, 1, tzinfo=timezone.utc)),
+        _run(run_id='new-terminal', state=RunState.FAILED,
+             updated_at=datetime(2026, 2, 2, tzinfo=timezone.utc)),
+    ]
+
+    selected = select_runs_for_list(runs)
+
+    assert [run.run_id for run in selected] == [
+        'active-new',
+        'active-old',
+        'new-terminal',
+        'old-terminal',
+    ]
+
+
+def test_run_list_caps_at_ten() -> None:
+    runs = [
+        _run(run_id=f'run-{i}', state=RunState.JOB_RUNNING)
+        for i in range(15)
+    ]
+
+    selected = select_runs_for_list(runs)
+
+    assert len(selected) == 10
+
+
+def test_render_run_status_includes_durable_fields() -> None:
+    run = _run(run_id='run-1', state=RunState.AWAITING_EXECUTION_APPROVAL)
+    actions = [
+        _action(
+            type_='submit_experiment_matrix',
+            classification=PolicyClassification.HONEYDEW_AND_HUMAN_APPROVAL,
+        ),
+    ]
+    jobs = [_job(JobStatus.SUCCEEDED), _job(JobStatus.RUNNING)]
+
+    view = build_run_status_view(run, actions, jobs)
+    message = render_run_status(view)
+
+    assert 'run-1' in message
+    assert 'AWAITING_EXECUTION_APPROVAL' in message
+    assert 'approve cluster execution' in message
+    assert 'succeeded 1' in message
+    assert 'running 1' in message
+    assert 'submit_experiment_matrix' in message
+
+
+def test_render_run_list_marks_terminal() -> None:
+    runs = [
+        _run(run_id='run-1', state=RunState.COMPLETE),
+        _run(run_id='run-2', state=RunState.JOB_RUNNING),
+    ]
+
+    message = render_run_list(select_runs_for_list(runs))
+
+    assert 'run-1' in message
+    assert 'terminal' in message
+    assert 'run-2' in message
+
+
+def test_bound_discord_message_truncates() -> None:
+    long = 'x' * (DISCORD_MESSAGE_LIMIT + 100)
+    bounded = bound_discord_message(long)
+    assert len(bounded) <= DISCORD_MESSAGE_LIMIT
+    assert bounded.endswith('...')
+
+    short = 'hello'
+    assert bound_discord_message(short) == short


### PR DESCRIPTION
Closes #94.

## What changed

Added two read-only slash commands to the research-orchestrator Discord control gateway (`discord_controls.py`):

- **`/research-status`** — resolves the run from the interaction channel's `discord_thread_id` (no run ID required in a thread); the configured main channel requires an explicit `run_id`. Rejects unknown threads, unknown run IDs, mismatched thread/run combinations, and unsupported channels via the existing `_resolve_controlled_run`.
- **`/research-list`** — deterministic, bounded list (main channel only): active runs first, then most-recently-updated terminal runs, capped at 10. Ordering uses `(updated_at desc, run_id desc)` so equal timestamps tie-break deterministically.

Status output is derived only from durable `RunRecord`, `ActionRecord`, and `JobRecord` data: state, phase, pending approval, job counts across every `JobStatus`, and next required action.

Approval gating: a pending `HONEYDEW_AND_HUMAN_APPROVAL` action is only shown as a human "next action" once `honeydew_approved` is true; before that the next action is derived from the current Honeydew-review state, so operators are never told to approve something the engine would reject.

Both commands are read-only projections — they never mutate runs, append events, create actions, or trigger recovery. Synchronous store reads run through `asyncio.to_thread` with error handling. Responses are bounded to Discord's message-length limit.

## Design

Status selection and rendering are pure functions, unit-tested without any Discord connection:

`pending_human_approval`, `job_status_counts`, `next_action_for`, `build_run_status_view`, `render_run_status`, `select_runs_for_list`, `render_run_list`, `bound_discord_message`.

## Test commands and results

```
python3 -m py_compile services/research-orchestrator/app/discord_controls.py services/research-orchestrator/tests/test_discord_and_opencode.py
# OK

cd services/research-orchestrator
.venv314/bin/python -m pytest tests/test_discord_and_opencode.py -q
# 50 passed

.venv314/bin/python -m pytest tests/ -q
# 171 passed

python3 scripts/check-doc-links.py
# Markdown links resolved successfully.
```

## Tests added

Thread-local resolution without a run ID; main-channel rejection when run ID omitted; unknown and mismatched thread/run IDs; unsupported-channel rejection; pending protocol/execution/contract-promotion/final-report approvals; the Honeydew-gate requirement for combined approvals; job counts across all seven statuses; active-first + recent-terminal ordering; deterministic ties and the 10-run limit; terminal runs with no pending action; output length bounding; and command registration. No live Discord calls.

No changes to the state machine, engine recovery, retry/checkpoint logic, SQLite/PostgreSQL schemas, workspace handling, `discord_adapter.py`, or PR #145.