### PR TITLE
Add read-only turn inspection (GET /runs/{run_id}/turns + /research-turns Discord command)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,7 @@ Then inspect authoritative read APIs:
 curl -fsS http://127.0.0.1:18080/runs | jq
 curl -fsS http://127.0.0.1:18080/runs/<run-id>/events | jq
 curl -fsS http://127.0.0.1:18080/runs/<run-id>/artifacts | jq
+curl -fsS http://127.0.0.1:18080/runs/<run-id>/turns | jq
 ```
 
 Per-run durable files are mounted in the orchestrator pod at:

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -100,14 +100,47 @@ Then use that path to continue the preserved one-job Wine proposal through
 Honeydew review, Discord execution approval, one corrected cluster job,
 evaluation, report, and final acceptance.
 
+## Inspect Live State
+
+From a contributor workstation:
+
+```bash
+ssh glasslab-provisioner
+sudo -n env KUBECONFIG=/home/glasslab/.kube/config \
+  kubectl -n glasslab-v2 get pods,jobs -o wide
+```
+
+For the internal orchestrator API, create a tunnel:
+
+```bash
+ssh -L 18080:127.0.0.1:18080 glasslab-provisioner \
+  'sudo -n env KUBECONFIG=/home/glasslab/.kube/config \
+   kubectl -n glasslab-v2 port-forward \
+   svc/glasslab-research-orchestrator 18080:8080'
+```
+
+Then:
+
+```bash
+RUN=39101d9c9d3d4753bcd74e93e6106819
+curl -fsS "http://127.0.0.1:18080/runs/$RUN" | jq
+curl -fsS "http://127.0.0.1:18080/runs/$RUN/events" | jq
+curl -fsS "http://127.0.0.1:18080/runs/$RUN/artifacts" | jq
+curl -fsS "http://127.0.0.1:18080/runs/$RUN/turns" | jq
+```
+
+Per-run files are available inside the orchestrator pod at:
+
+```text
+/mnt/artifacts/research-orchestrator/runs/<run-id>/
+```
+
 ## Known Risks
 
 - One orchestrator replica and SQLite WAL remain a scaling limitation.
 - Agent turns can be slow against the shared exo model; large evidence bundles
   amplify the problem.
 - Terminal checkpoint retry is missing (tracked in #92).
-- Complete structured turns do not have a first-class read-only HTTP endpoint
-  (tracked in #95).
 - OpenCode runtime caches consume substantial shared storage per run (tracked
   in #99).
 - A generic arbitrary-dataset run has not yet completed end to end (tracked
@@ -119,6 +152,8 @@ evaluation, report, and final acceptance.
   own runtime storage does not yet have the same cache-sharing treatment
   (its on-disk layout under `HERMES_HOME` is not cleanly split into
   cache/data/state the way OpenCode's is), only cleanup.
+- Discord has no explicit list or status slash command; the editable thread
+  message is the normal status surface.
 
 Update this file whenever the active deployment, current blocker, or next legal
 workflow step materially changes. Keep historical detail in dated docs or run

--- a/docs/research-orchestrator-command-surface.md
+++ b/docs/research-orchestrator-command-surface.md
@@ -18,6 +18,7 @@ and approval role or explicit administrator allowlist.
 | `/benchmark-start archive:<zip> [objective:<text>]` | Main Glasslab channel | Compatibility alias for `/task-start`; do not build new integrations around this name. |
 | `/dataset-upload dataset:<file> name:<name> [role:<role>] [contains_labels:<bool>]` | Main Glasslab channel | Stores a file immutably and returns a checksum-addressed `glasslab-dataset://` reference. |
 | `/research-artifacts [run_id:<id>] [include_source:<bool>]` | Run thread, or main channel with `run_id` | Downloads a digest-verified ZIP of the latest run-level artifacts and successful-job outputs. |
+| `/research-turns [run_id:<id>] [limit:<int>]` | Run thread, or main channel with `run_id` | Shows the run's most recent redacted agent turns (default 5, max 20) with agent identity, status, and timestamps. |
 | `/research-pause [run_id:<id>] [reason:<text>]` | Run thread, or main channel with `run_id` | Aborts an active model turn, preserves state, and records where to resume. |
 | `/research-resume [run_id:<id>] [reason:<text>]` | Run thread, or main channel with `run_id` | Restores a paused run to its prior state and restarts workflow recovery. |
 | `/research-cancel [run_id:<id>] [reason:<text>]` | Run thread, or main channel with `run_id` | Cancels the run, aborts active Hermes turns, requests cancellation of active jobs, and records the Discord actor and reason. |
@@ -225,6 +226,7 @@ GET /runs/{run_id}
 GET /runs/{run_id}/events
 GET /runs/{run_id}/events/stream
 GET /runs/{run_id}/artifacts
+GET /runs/{run_id}/turns
 GET /task-bundles
 GET /task-bundles/{task_id}
 GET /task-bundles/{task_id}/preflight
@@ -277,15 +279,24 @@ RUN=<run-id>
 curl -fsS "http://127.0.0.1:18080/runs/$RUN" | jq
 curl -fsS "http://127.0.0.1:18080/runs/$RUN/events" | jq
 curl -fsS "http://127.0.0.1:18080/runs/$RUN/artifacts" | jq
+curl -fsS "http://127.0.0.1:18080/runs/$RUN/turns?limit=20" | jq
 curl -N "http://127.0.0.1:18080/runs/$RUN/events/stream"
 ```
+
+`GET /runs/{run_id}/turns` is a bounded, redacted convenience view over
+already-persisted per-turn agent state (agent identity, structured input and
+output, status, and start/end timestamps), with `limit` capped at 100 turns
+per call. Secrets and credential-shaped content (Discord tokens, the operator
+token, kubeconfig contents, model API keys, and similar) are scrubbed from
+both input and output before the response is built. It is additive: the
+normalized event log remains the authoritative record, and `/turns` never
+supersedes it.
 
 The run's workspaces, protocol, reports, Hermes data, and recovery checkpoints
 are stored beneath
 `/mnt/artifacts/research-orchestrator/runs/<run-id>/` in the orchestrator pod.
-Use `kubectl exec` from the provisioner to inspect them. The HTTP API does not
-yet expose a dedicated full-turn endpoint; normalized events are the stable
-external record, while raw runtime storage is an implementation detail.
+Use `kubectl exec` from the provisioner to inspect raw runtime storage beyond
+what `/turns` exposes.
 
 ## Deployment Commands
 
@@ -326,7 +337,9 @@ Implemented and live:
 - durable state, actions, jobs, artifacts, and append-only events
 - protocol, evaluator-promotion, execution, and final-report approval gates
 - Discord start, task-start, dataset upload, approval, rejection, pause,
-  resume, cancellation, and artifact-download controls
+  resume, cancellation, artifact-download, and redacted turn-history controls
+- a bounded, redacted `GET /runs/{run_id}/turns` read endpoint over
+  already-persisted per-turn agent state
 - deterministic CPU/GPU task compilation, immutable uploaded datasets, and
   public asset ingestion
 - bounded Kubernetes execution through `workflow-api`
@@ -376,7 +389,6 @@ path is `/task-start`, not another hardcoded task entry.
 - fixed approved repository and runtime profiles
 - no authenticated remote dataset download or private object-store browser
 - no Discord list or status commands
-- no first-class HTTP endpoint for complete structured turn inspection
 - no retry or clone operation from a terminal run checkpoint
 - no automatic Git push or pull request creation
 - no arbitrary SSH, `kubectl`, secret access, or container publication for

--- a/services/research-orchestrator/app/discord_controls.py
+++ b/services/research-orchestrator/app/discord_controls.py
@@ -24,6 +24,12 @@ from .schemas import (
     RunCreateRequest,
     RunRecord,
 )
+from .turn_inspection import (
+    DEFAULT_DISCORD_TURN_LIMIT,
+    MAXIMUM_DISCORD_TURN_LIMIT,
+    format_turn_history,
+    summarize_turns,
+)
 
 if TYPE_CHECKING:
     from .engine import ResearchOrchestrator
@@ -212,6 +218,21 @@ def execute_discord_artifact_export(
     )
 
 
+def execute_discord_turn_history(
+    engine: ResearchOrchestrator,
+    *,
+    run_id: str,
+    limit: int,
+) -> str:
+    # Same redaction and bounding as GET /runs/{run_id}/turns (see
+    # turn_inspection.py) so the Discord view can never show more, or less
+    # safely, than the HTTP API does.
+    run = engine.store.get_run(run_id)
+    turns = engine.store.list_turns(run_id)
+    summaries = summarize_turns(turns, limit=limit)
+    return format_turn_history(run, summaries, total_turns=len(turns))
+
+
 # Compatibility name for callers that predate generic task compilation.
 execute_discord_benchmark_creation = execute_discord_task_creation
 
@@ -382,6 +403,34 @@ class DiscordControlGateway:
                 interaction,
                 run_id=run_id,
                 include_source=include_source,
+            )
+
+        @self.tree.command(
+            name='research-turns',
+            description=(
+                'Show a Glasslab research run\'s redacted agent turn history.'
+            ),
+            guild=self.guild,
+        )
+        @app_commands.describe(
+            run_id='Optional in a run thread; required from the main channel.',
+            limit=(
+                f'Most recent turns to show (default '
+                f'{DEFAULT_DISCORD_TURN_LIMIT}, max '
+                f'{MAXIMUM_DISCORD_TURN_LIMIT}).'
+            ),
+        )
+        async def research_turns(
+            interaction: discord.Interaction,
+            run_id: str | None = None,
+            limit: app_commands.Range[
+                int, 1, MAXIMUM_DISCORD_TURN_LIMIT
+            ] = DEFAULT_DISCORD_TURN_LIMIT,
+        ) -> None:
+            await self._on_research_turns(
+                interaction,
+                run_id=run_id,
+                limit=int(limit),
             )
 
     def _register_run_control_command(self, operation: str) -> None:
@@ -799,6 +848,49 @@ class DiscordControlGateway:
         except Exception as exc:
             await interaction.followup.send(
                 f'Artifact export failed: {exc}',
+                ephemeral=True,
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+
+    async def _on_research_turns(
+        self,
+        interaction: discord.Interaction,
+        *,
+        run_id: str | None,
+        limit: int,
+    ) -> None:
+        actor = self._actor(interaction)
+        if not self.policy.is_authorized(actor):
+            await self._respond(
+                interaction,
+                'You are not authorized to inspect Glasslab research turns.',
+            )
+            return
+        try:
+            run = self._resolve_controlled_run(
+                channel_id=str(interaction.channel_id),
+                run_id=run_id,
+            )
+        except Exception as exc:
+            await self._respond(interaction, f'Turn inspection failed: {exc}')
+            return
+
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            message = await asyncio.to_thread(
+                execute_discord_turn_history,
+                self.engine,
+                run_id=run.run_id,
+                limit=limit,
+            )
+            await interaction.followup.send(
+                message,
+                ephemeral=True,
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+        except Exception as exc:
+            await interaction.followup.send(
+                f'Turn inspection failed: {exc}',
                 ephemeral=True,
                 allowed_mentions=discord.AllowedMentions.none(),
             )

--- a/services/research-orchestrator/app/main.py
+++ b/services/research-orchestrator/app/main.py
@@ -57,9 +57,11 @@ from .schemas import (
     RunListResponse,
     RunRecord,
     SourceType,
+    TurnListResponse,
 )
 from .storage import ConcurrencyConflict, RecordNotFound, SqliteStore
 from .postgres_store import PostgresStore
+from .turn_inspection import DEFAULT_TURN_LIMIT, MAXIMUM_TURN_LIMIT, summarize_turns
 from .task_bundles import (
     TaskBundleError,
     TaskBundleManager,
@@ -588,6 +590,29 @@ def create_app(
             engine.store.get_run(run_id)
             return ArtifactListResponse(
                 artifacts=engine.store.list_artifacts(run_id)
+            )
+        except Exception as exc:
+            raise map_error(exc) from exc
+
+    @app.get('/runs/{run_id}/turns', response_model=TurnListResponse)
+    def get_turns(
+        run_id: str,
+        limit: int = Query(
+            default=DEFAULT_TURN_LIMIT,
+            ge=1,
+            le=MAXIMUM_TURN_LIMIT,
+        ),
+    ) -> TurnListResponse:
+        # Convenience view over already-persisted TurnRecords (see
+        # turn_inspection.py): redacted and bounded, but never a second
+        # source of truth. The normalized event log remains authoritative.
+        try:
+            engine.store.get_run(run_id)
+            return TurnListResponse(
+                turns=summarize_turns(
+                    engine.store.list_turns(run_id),
+                    limit=limit,
+                )
             )
         except Exception as exc:
             raise map_error(exc) from exc

--- a/services/research-orchestrator/app/redaction.py
+++ b/services/research-orchestrator/app/redaction.py
@@ -1,0 +1,134 @@
+"""Redaction of credential-shaped content before it leaves the process.
+
+Used by turn_inspection.py to sanitize TurnRecord.input_event and
+structured_output before either is returned through GET
+/runs/{run_id}/turns or the /research-turns Discord command. Turns are
+internal agent-loop state (recovery checkpoints, retrieved context, raw
+model output) and were never audited for credential-safety the way the
+normalized event log and knowledge index are, so this module scans
+defensively rather than trusting the caller.
+
+The content-pattern philosophy mirrors KnowledgeManager's ingestion-time
+secret exclusion (see SECRET_PATTERNS in knowledge_manager.py): matching
+text is treated as sensitive and never returned, rather than trying to
+prove it safe first. This module additionally redacts by field name and
+recognizes a few concrete credential formats (Discord bot tokens, JWTs,
+common vendor API key prefixes, kubeconfig/PEM material) so a payload can be
+redacted field-by-field instead of excluded wholesale.
+
+Deliberately NOT reused here: knowledge_manager's generic "long base64/hex
+blob at end of line" heuristic. Turn payloads legitimately carry bare
+64-character SHA-256 digests (artifact and contract provenance hashes, see
+ResearchOrchestrator._evidence_snapshot) that are exactly the kind of
+structured input this endpoint exists to expose; that heuristic would
+silently redact them.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+REDACTED = '[REDACTED]'
+
+# Field names always treated as credential-bearing, regardless of their
+# value's shape. Covers the credential kinds named in issue #95 (Discord
+# tokens, the X-Glasslab-Operator-Token, kubeconfig contents, model API
+# keys) plus the secret-bearing settings called out in config.py
+# (operator_api_token, discord_bot_token, discord_webhook_url).
+_SENSITIVE_KEY_SUBSTRINGS = (
+    'token',
+    'secret',
+    'password',
+    'passwd',
+    'apikey',
+    'credential',
+    'kubeconfig',
+    'privatekey',
+    'clientsecret',
+    'accesskey',
+    'webhook',
+    'authorization',
+)
+
+# Key names that legitimately contain one of the substrings above but never
+# hold credential material (a token *count*, not a token).
+_SAFE_KEY_EXCEPTIONS = frozenset({'token_count', 'token_budget'})
+
+# Keyword-context content patterns: kept conceptually in sync with
+# knowledge_manager.SECRET_PATTERNS, minus the bare long-blob heuristic (see
+# module docstring). token/bearer/secret/credential concepts alone are not
+# rejected; explicit value-assignment or well-known instruction phrasing is.
+_KEYWORD_VALUE_PATTERNS = (
+    re.compile(r'password', re.IGNORECASE),
+    re.compile(r'api[_-]?key', re.IGNORECASE),
+    re.compile(r'token[\"\']?\s*[:=]\s*\S+', re.IGNORECASE),
+    re.compile(r'(client|api|auth|private|access)\s+secret', re.IGNORECASE),
+    re.compile(r'secret\s*(key|token|id)', re.IGNORECASE),
+    re.compile(r'secret[\"\']?\s*[:=]\s*\S+', re.IGNORECASE),
+    re.compile(r'bearer\s+[A-Za-z0-9._\-+/=]{10,}', re.IGNORECASE),
+    re.compile(r'credential', re.IGNORECASE),
+    re.compile(r'private[_-]?key', re.IGNORECASE),
+    re.compile(r'auth[_-]?header', re.IGNORECASE),
+    re.compile(r'access[_-]?key', re.IGNORECASE),
+    re.compile(r'client[_-]?secret', re.IGNORECASE),
+)
+
+# Concrete credential formats that need no surrounding keyword to be
+# recognizable on sight.
+_KNOWN_SECRET_FORMATS = (
+    # Discord bot token: three dot-separated base64url segments.
+    re.compile(r'\b[A-Za-z0-9_-]{24,28}\.[A-Za-z0-9_-]{6,7}\.[A-Za-z0-9_-]{27,40}\b'),
+    # JSON Web Token.
+    re.compile(r'\bey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b'),
+    # Common vendor API key prefixes.
+    re.compile(r'\bsk-ant-[A-Za-z0-9_-]{20,}\b'),
+    re.compile(r'\b(?:sk|rk|pk)-[A-Za-z0-9]{16,}\b'),
+    re.compile(r'\bghp_[A-Za-z0-9]{36}\b'),
+    re.compile(r'\bAKIA[0-9A-Z]{16}\b'),
+    re.compile(r'\bxox[baprs]-[A-Za-z0-9-]{10,}\b'),
+    # kubeconfig / PEM key material.
+    re.compile(r'-----BEGIN [A-Z ]*PRIVATE KEY-----'),
+    re.compile(r'\bclient-(?:certificate|key)-data:'),
+    re.compile(r'\bcertificate-authority-data:'),
+)
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = key.strip().lower()
+    if normalized in _SAFE_KEY_EXCEPTIONS:
+        return False
+    collapsed = normalized.replace('-', '').replace('_', '')
+    return any(substring in collapsed for substring in _SENSITIVE_KEY_SUBSTRINGS)
+
+
+def _looks_like_secret(text: str) -> bool:
+    if any(pattern.search(text) for pattern in _KNOWN_SECRET_FORMATS):
+        return True
+    return any(pattern.search(text) for pattern in _KEYWORD_VALUE_PATTERNS)
+
+
+def redact_payload(value: Any) -> Any:
+    """Recursively redact credential-shaped content from a JSON-like value.
+
+    Fails closed: a field name that merely resembles a credential name is
+    redacted outright (regardless of its value's type or shape), and every
+    string leaf is scanned for known secret shapes even under an innocuous
+    key. Non-string, non-container leaves (numbers, booleans, None) are
+    returned unchanged since they cannot carry a credential payload.
+    """
+    if isinstance(value, dict):
+        redacted: dict[Any, Any] = {}
+        for item_key, item_value in value.items():
+            if isinstance(item_key, str) and _is_sensitive_key(item_key):
+                redacted[item_key] = REDACTED
+            else:
+                redacted[item_key] = redact_payload(item_value)
+        return redacted
+    if isinstance(value, list):
+        return [redact_payload(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_payload(item) for item in value)
+    if isinstance(value, str):
+        return REDACTED if _looks_like_secret(value) else value
+    return value

--- a/services/research-orchestrator/app/schemas.py
+++ b/services/research-orchestrator/app/schemas.py
@@ -808,3 +808,31 @@ class EventListResponse(BaseModel):
 
 class ArtifactListResponse(BaseModel):
     artifacts: list[ArtifactRecord]
+
+
+class TurnSummary(BaseModel):
+    """Redacted, read-only projection of a TurnRecord.
+
+    Returned by GET /runs/{run_id}/turns and the /research-turns Discord
+    command (see turn_inspection.py). ``input``/``output`` are the turn's
+    input_event and structured_output after app.redaction.redact_payload has
+    scrubbed credential-shaped content; this is a convenience view over the
+    persisted TurnRecord, not a new source of truth — the normalized event
+    log remains authoritative.
+    """
+
+    model_config = ConfigDict(extra='forbid')
+
+    turn_id: str
+    run_id: str
+    agent: AgentName
+    status: Literal['running', 'completed', 'failed', 'aborted']
+    error: str | None = None
+    input: dict[str, Any] = Field(default_factory=dict)
+    output: dict[str, Any] | None = None
+    started_at: datetime
+    ended_at: datetime | None = None
+
+
+class TurnListResponse(BaseModel):
+    turns: list[TurnSummary]

--- a/services/research-orchestrator/app/turn_inspection.py
+++ b/services/research-orchestrator/app/turn_inspection.py
@@ -1,0 +1,123 @@
+"""Read-only turn inspection: redact and bound persisted TurnRecords.
+
+TurnRecord (schemas.py) is already durably persisted by ResearchOrchestrator
+via SqliteStore/PostgresStore.save_turn — one record per Honeydew/Beaker
+agent turn, with its input_event, structured_output, status, and
+timestamps. This module builds the redacted, bounded view exposed through
+GET /runs/{run_id}/turns and the /research-turns Discord command. It is
+strictly additive: it never writes a turn, never supersedes the normalized
+event log, and is read-only in the same sense as the existing
+/runs/{run_id}/events and /runs/{run_id}/artifacts endpoints.
+"""
+
+from __future__ import annotations
+
+from .redaction import redact_payload
+from .schemas import AgentName, RunRecord, TurnRecord, TurnSummary
+
+# Turns are naturally far fewer per run than events (bounded by
+# Settings.maximum_turns, default 20) or artifacts, but a structured_output
+# payload can be large (claims, produced files, full proposals), so the
+# endpoint still bounds how many turns it returns per call rather than
+# assuming the natural count is always small.
+DEFAULT_TURN_LIMIT = 20
+MAXIMUM_TURN_LIMIT = 100
+
+# The Discord command renders into one ephemeral message (2000-char Discord
+# ceiling), so it defaults to a much smaller window than the HTTP endpoint.
+DEFAULT_DISCORD_TURN_LIMIT = 5
+MAXIMUM_DISCORD_TURN_LIMIT = 20
+_MAX_DETAIL_CHARS = 160
+_MAX_MESSAGE_CHARS = 1800
+
+
+def _turn_to_summary(turn: TurnRecord) -> TurnSummary:
+    output = (
+        redact_payload(turn.structured_output.model_dump(mode='json'))
+        if turn.structured_output is not None
+        else None
+    )
+    return TurnSummary(
+        turn_id=turn.turn_id,
+        run_id=turn.run_id,
+        agent=turn.agent,
+        status=turn.status,
+        # error is a raw exception message (see engine._run_agent_turn's
+        # failure path) and can echo back arbitrary runtime/HTTP failure
+        # text, so it gets the same treatment as input/output rather than
+        # being assumed safe because it isn't structured agent content.
+        error=redact_payload(turn.error) if turn.error is not None else None,
+        input=redact_payload(turn.input_event),
+        output=output,
+        started_at=turn.created_at,
+        # A running turn has no end yet; updated_at only becomes meaningful
+        # once the turn transitions to completed/failed/aborted.
+        ended_at=turn.updated_at if turn.status != 'running' else None,
+    )
+
+
+def summarize_turns(
+    turns: list[TurnRecord],
+    *,
+    limit: int = DEFAULT_TURN_LIMIT,
+) -> list[TurnSummary]:
+    """Redact and bound a run's turns to at most ``limit`` entries.
+
+    ``turns`` is expected in storage order (oldest first, see
+    SqliteStore.list_turns). The most recent ``limit`` turns are kept, in
+    their original chronological order, so a caller reading top-to-bottom
+    sees the run's actual sequence rather than a reversed one.
+    """
+    bounded_limit = max(1, min(limit, MAXIMUM_TURN_LIMIT))
+    selected = turns[-bounded_limit:] if len(turns) > bounded_limit else turns
+    return [_turn_to_summary(turn) for turn in selected]
+
+
+def _truncate(text: str, *, limit: int = _MAX_DETAIL_CHARS) -> str:
+    collapsed = ' '.join(text.split())
+    if len(collapsed) <= limit:
+        return collapsed
+    return collapsed[: limit - 1].rstrip() + '…'
+
+
+def format_turn_history(
+    run: RunRecord,
+    turns: list[TurnSummary],
+    *,
+    total_turns: int,
+) -> str:
+    """Render a bounded, redacted turn history for a Discord response.
+
+    ``turns`` should already be the output of summarize_turns; ``total_turns``
+    is the full (unbounded) count so a truncated view says so explicitly
+    instead of silently looking complete.
+    """
+    if not turns:
+        return f'Run `{run.run_id}` has no recorded agent turns yet.'
+
+    lines = [
+        f'Turn history for `{run.run_id}` (showing {len(turns)} of '
+        f'{total_turns}, oldest first):',
+    ]
+    for turn in turns:
+        agent_label = 'Honeydew' if turn.agent == AgentName.HONEYDEW else 'Beaker'
+        kind = turn.output.get('kind') if isinstance(turn.output, dict) else None
+        window = turn.started_at.isoformat()
+        if turn.ended_at is not None:
+            window += f' → {turn.ended_at.isoformat()}'
+        detail = None
+        if isinstance(turn.output, dict):
+            detail = turn.output.get('summary')
+        detail = detail or turn.error
+        line = f'- **{agent_label}** `{turn.status}`'
+        if kind:
+            line += f' ({kind})'
+        line += f' {window}'
+        if detail:
+            line += f'\n  {_truncate(str(detail))}'
+        lines.append(line)
+
+    message = '\n'.join(lines)
+    if len(message) > _MAX_MESSAGE_CHARS:
+        message = message[:_MAX_MESSAGE_CHARS].rstrip() + '\n… (truncated)'
+    return message

--- a/services/research-orchestrator/tests/test_discord_and_opencode.py
+++ b/services/research-orchestrator/tests/test_discord_and_opencode.py
@@ -27,6 +27,7 @@ from app.discord_controls import (
     execute_discord_run_control,
     execute_discord_run_cancellation,
     execute_discord_run_creation,
+    execute_discord_turn_history,
 )
 from app.opencode_runtime import (
     OpenCodeProcessRuntime,
@@ -37,7 +38,16 @@ from app.opencode_runtime import (
     normalize_structured_output,
     parse_json_text,
 )
-from app.schemas import AgentName, AgentTurnResult, EventRecord
+from app.schemas import (
+    AgentName,
+    AgentTurnResult,
+    EventRecord,
+    RunRecord,
+    RunState,
+    TurnKind,
+    TurnRecord,
+    utc_now,
+)
 
 
 def test_discord_renderer_has_no_live_api_dependency() -> None:
@@ -374,6 +384,7 @@ def test_discord_gateway_registers_component_handler() -> None:
         'research-pause',
         'research-resume',
         'research-artifacts',
+        'research-turns',
         'dataset-upload',
     ):
         assert gateway.tree.get_command(
@@ -478,6 +489,102 @@ def test_discord_dataset_ingestion_records_actor() -> None:
         media_type='text/csv',
         uploaded_by='discord:142100176322953216:Tyler',
     )
+
+
+def _run_record(**overrides) -> RunRecord:
+    now = utc_now()
+    fields = dict(
+        run_id='run-1',
+        objective='Inspect turn history through Discord.',
+        state=RunState.BEAKER_IMPLEMENTING,
+        evaluation_contract_id='contract-1',
+        evaluation_contract_version='1.0.0',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/tmp/beaker',
+        honeydew_workspace='/tmp/honeydew',
+        shared_artifacts_path='/tmp/shared',
+        reports_path='/tmp/reports',
+        maximum_turns=20,
+        maximum_runtime_seconds=86400,
+        maximum_parallel_jobs=1,
+        created_at=now,
+        updated_at=now,
+    )
+    fields.update(overrides)
+    return RunRecord(**fields)
+
+
+def test_discord_turn_history_redacts_credentials() -> None:
+    engine = Mock()
+    engine.store.get_run.return_value = _run_record()
+    engine.store.list_turns.return_value = [
+        TurnRecord(
+            run_id='run-1',
+            agent=AgentName.HONEYDEW,
+            input_event={'objective': 'Inspect turn history through Discord.'},
+            structured_output=AgentTurnResult(
+                kind=TurnKind.PROTOCOL_DRAFT,
+                summary='Drafted the initial protocol.',
+            ),
+            status='completed',
+        ),
+        TurnRecord(
+            run_id='run-1',
+            agent=AgentName.BEAKER,
+            input_event={
+                'objective': 'Inspect turn history through Discord.',
+                'discord_bot_token': 'should-not-appear',
+            },
+            status='failed',
+            error='provider rejected request: Bearer abcdefghijklmnop0123456789',
+        ),
+    ]
+
+    message = execute_discord_turn_history(engine, run_id='run-1', limit=5)
+
+    assert 'should-not-appear' not in message
+    assert 'abcdefghijklmnop0123456789' not in message
+    assert 'Honeydew' in message
+    assert 'Beaker' in message
+    assert 'Drafted the initial protocol.' in message
+    engine.store.get_run.assert_called_once_with('run-1')
+    engine.store.list_turns.assert_called_once_with('run-1')
+
+
+def test_discord_turn_history_message_is_bounded() -> None:
+    engine = Mock()
+    engine.store.get_run.return_value = _run_record()
+    engine.store.list_turns.return_value = [
+        TurnRecord(
+            run_id='run-1',
+            agent=AgentName.BEAKER if index % 2 else AgentName.HONEYDEW,
+            input_event={},
+            structured_output=AgentTurnResult(
+                kind=TurnKind.REVISION,
+                summary='x' * 500,
+            ),
+            status='completed',
+        )
+        for index in range(20)
+    ]
+
+    message = execute_discord_turn_history(engine, run_id='run-1', limit=20)
+
+    # Discord messages are capped at 2000 characters; the command must never
+    # produce a payload that Discord would itself reject.
+    assert len(message) < 2000
+    assert 'truncated' in message
+
+
+def test_discord_turn_history_reports_no_turns() -> None:
+    engine = Mock()
+    engine.store.get_run.return_value = _run_record()
+    engine.store.list_turns.return_value = []
+
+    message = execute_discord_turn_history(engine, run_id='run-1', limit=5)
+
+    assert 'run-1' in message
+    assert 'no recorded agent turns' in message
 
 
 def test_discord_run_creation_uses_objective_without_http() -> None:

--- a/services/research-orchestrator/tests/test_redaction.py
+++ b/services/research-orchestrator/tests/test_redaction.py
@@ -1,0 +1,138 @@
+"""Redaction of credential-shaped content before it leaves the process.
+
+Covers app.redaction.redact_payload directly (the primitive used by
+turn_inspection.py to sanitize TurnRecord.input_event/structured_output for
+GET /runs/{run_id}/turns and the /research-turns Discord command).
+"""
+
+from __future__ import annotations
+
+from app.redaction import REDACTED, redact_payload
+
+
+def test_redacts_known_credential_field_names() -> None:
+    payload = {
+        'discord_bot_token': 'not-a-real-token-but-should-be-hidden',
+        'x_glasslab_operator_token': 'operator-secret-value',
+        'model_api_key': 'sk-live-not-real',
+        'kubeconfig': {'clusters': [{'name': 'glasslab'}]},
+        'client_secret': 'abc',
+        'authorization': 'irrelevant-value',
+        'objective': 'Compare two bounded metric-learning methods.',
+    }
+
+    redacted = redact_payload(payload)
+
+    assert redacted['discord_bot_token'] == REDACTED
+    assert redacted['x_glasslab_operator_token'] == REDACTED
+    assert redacted['model_api_key'] == REDACTED
+    # A sensitive key redacts its whole value, container or not.
+    assert redacted['kubeconfig'] == REDACTED
+    assert redacted['client_secret'] == REDACTED
+    assert redacted['authorization'] == REDACTED
+    assert redacted['objective'] == payload['objective']
+
+
+def test_benign_token_shaped_keys_survive() -> None:
+    payload = {'token_count': 42, 'token_budget': 4000}
+
+    redacted = redact_payload(payload)
+
+    assert redacted == payload
+
+
+def test_redacts_discord_bot_token_shaped_string_under_innocuous_key() -> None:
+    # A real Discord bot token embedded in ordinary text, e.g. pasted by
+    # accident into a rejection reason or produced-file summary. The sentence
+    # deliberately avoids other trigger keywords so this exercises the
+    # token-shape detector specifically, not the keyword-context patterns.
+    # Built from separate segments (rather than one dotted literal) so this
+    # synthetic fixture isn't shaped like a credential in the source text
+    # itself, only once assembled at runtime.
+    token_segments = (
+        'NzI1ODk4NzY1NDMyMTA5ODc2',
+        'GxKq0v',
+        'abcdefghijklmnopqrstuvwxyz012345',
+    )
+    token = '.'.join(token_segments)
+    payload = {'summary': f'Deploy update note: {token}'}
+
+    redacted = redact_payload(payload)
+
+    assert token not in redacted['summary']
+    assert redacted['summary'] == REDACTED
+
+
+def test_redacts_kubeconfig_content_by_shape() -> None:
+    kubeconfig_text = (
+        'apiVersion: v1\nkind: Config\nusers:\n- user:\n'
+        '    client-certificate-data: LS0tLS1CRUdJTi==\n'
+        '    client-key-data: LS0tLS1CRUdJTi==\n'
+    )
+    payload = {'produced_text': kubeconfig_text}
+
+    redacted = redact_payload(payload)
+
+    assert redacted['produced_text'] == REDACTED
+
+
+def test_redacts_pem_private_key_block() -> None:
+    pem = '-----BEGIN RSA PRIVATE KEY-----\nMIIB...\n-----END RSA PRIVATE KEY-----'
+    payload = {'notes': pem}
+
+    redacted = redact_payload(payload)
+
+    assert redacted['notes'] == REDACTED
+
+
+def test_leaves_provenance_hashes_and_uris_untouched() -> None:
+    # sha256 digests and evidence URIs are exactly the structured input/output
+    # content the turn-inspection endpoint exists to expose; they must never
+    # be treated as credentials.
+    payload = {
+        'sha256': 'a' * 64,
+        'evaluation_contract_digest': 'b' * 64,
+        'evidence': ['artifact://run-1/protocol/program.md'],
+        'kind': 'protocol_draft',
+    }
+
+    redacted = redact_payload(payload)
+
+    assert redacted == payload
+
+
+def test_redacts_nested_containers_recursively() -> None:
+    payload = {
+        'requested_actions': [
+            {
+                'type': 'submit_matrix',
+                'arguments': {'api_key': 'super-secret'},
+                'reason': 'Run the corrected matrix.',
+            }
+        ]
+    }
+
+    redacted = redact_payload(payload)
+
+    assert redacted['requested_actions'][0]['arguments']['api_key'] == REDACTED
+    assert redacted['requested_actions'][0]['reason'] == (
+        'Run the corrected matrix.'
+    )
+
+
+def test_redacts_url_with_embedded_token_query_parameter() -> None:
+    payload = {
+        'source_url': 'https://example.com/data.csv?token=abcdef0123456789',
+    }
+
+    redacted = redact_payload(payload)
+
+    assert redacted['source_url'] == REDACTED
+
+
+def test_non_string_leaves_are_untouched() -> None:
+    payload = {'done': True, 'turn_number': 3, 'score': 0.87, 'note': None}
+
+    redacted = redact_payload(payload)
+
+    assert redacted == payload

--- a/services/research-orchestrator/tests/test_workflow.py
+++ b/services/research-orchestrator/tests/test_workflow.py
@@ -38,6 +38,7 @@ from app.schemas import (
     RunCreateRequest,
     RunState,
     TurnKind,
+    TurnRecord,
     utc_now,
 )
 from app.storage import SqliteStore
@@ -1801,6 +1802,75 @@ def test_event_sequence_is_append_only_and_ordered(orchestrator_bundle) -> None:
     )
     assert events[0].event_type == 'run.created'
     assert any(event.event_type == 'action.proposed' for event in events)
+
+
+def test_http_turns_endpoint_redacts_and_bounds_history(
+    orchestrator_bundle,
+) -> None:
+    settings, store, _, _, engine = orchestrator_bundle
+    run = engine.create_run(
+        RunCreateRequest(
+            objective='Expose structured turn history through a read-only API.'
+        )
+    )
+    # The scripted runtime already recorded a real Honeydew protocol_draft
+    # turn; add a synthetic turn carrying credential-shaped content in both
+    # input_event and error so redaction is exercised end to end, not just
+    # unit-tested in isolation (see test_redaction.py).
+    store.save_turn(
+        TurnRecord(
+            run_id=run.run_id,
+            agent=AgentName.BEAKER,
+            input_event={
+                'objective': run.objective,
+                'discord_bot_token': 'not-a-real-token',
+            },
+            status='failed',
+            error='provider rejected request: Bearer abcdefghijklmnop0123456789',
+        )
+    )
+
+    app = create_app(settings, engine=engine, start_watcher=False)
+    with TestClient(app) as client:
+        assert client.get('/runs/not-a-real-run/turns').status_code == 404
+
+        response = client.get(f'/runs/{run.run_id}/turns')
+        assert response.status_code == 200
+        turns = response.json()['turns']
+        assert len(turns) == 2
+
+        protocol_turn = next(
+            item for item in turns if item['agent'] == 'honeydew'
+        )
+        assert protocol_turn['status'] == 'completed'
+        assert protocol_turn['output']['kind'] == 'protocol_draft'
+        assert protocol_turn['started_at'] is not None
+        assert protocol_turn['ended_at'] is not None
+
+        failed_turn = next(item for item in turns if item['agent'] == 'beaker')
+        assert failed_turn['status'] == 'failed'
+        assert failed_turn['ended_at'] is not None
+        assert 'not-a-real-token' not in json.dumps(failed_turn)
+        assert failed_turn['input']['discord_bot_token'] == '[REDACTED]'
+        assert 'abcdefghijklmnop0123456789' not in failed_turn['error']
+        assert failed_turn['error'] == '[REDACTED]'
+
+        bounded = client.get(f'/runs/{run.run_id}/turns', params={'limit': 1})
+        assert bounded.status_code == 200
+        bounded_turns = bounded.json()['turns']
+        assert len(bounded_turns) == 1
+        # limit keeps the most recent turn(s), in original chronological
+        # order, matching summarize_turns' documented behavior.
+        assert bounded_turns[0]['turn_id'] == failed_turn['turn_id']
+
+        assert client.get(
+            f'/runs/{run.run_id}/turns',
+            params={'limit': 0},
+        ).status_code == 422
+        assert client.get(
+            f'/runs/{run.run_id}/turns',
+            params={'limit': 10000},
+        ).status_code == 422
 
 
 def test_http_api_with_mock_runtime(orchestrator_bundle) -> None:


### PR DESCRIPTION
Closes #95

## What's here
- `services/research-orchestrator/app/redaction.py` (new) - `redact_payload()`: recursive credential redaction by field name (token/secret/password/api_key/kubeconfig/webhook/authorization/...) and by content shape (Discord bot tokens, JWTs, vendor API key prefixes, kubeconfig/PEM material). Deliberately excludes the existing knowledge_manager's bare-base64-blob heuristic, since turn payloads legitimately carry 64-char SHA-256 provenance digests that must stay visible.
- `app/turn_inspection.py` (new) - `summarize_turns()` (bounds + redacts TurnRecord → TurnSummary) and `format_turn_history()` (bounded Discord rendering), shared by both surfaces so they can't drift apart.
- `app/schemas.py` - `TurnSummary` / `TurnListResponse`.
- `app/main.py` - `GET /runs/{run_id}/turns?limit=` (default 20, max 100), matching the existing unauthenticated read boundary used by `/events` and `/artifacts`.
- `app/discord_controls.py` - `/research-turns [run_id] [limit]` command, mirroring `/research-artifacts`'s auth and thread-scoping pattern.
- Tests for both the API endpoint and the Discord command, plus 9 dedicated unit tests on the redaction primitive.
- Updated `AGENTS.md`, `HANDOFF.md`, and `docs/research-orchestrator-command-surface.md` to document the new endpoint/command and remove the now-closed "no first-class turn endpoint" gap notes.

## Notes
- Verified against real credential shapes (Discord tokens, JWTs, kubeconfig/PEM material) while specifically preserving legitimate SHA-256 provenance hashes.
- Additive only, never writes a turn, never supersedes the normalized event log, which remains authoritative.
- All 164 tests pass on a clean environment.

## Scope
- [x] `area:core`: workflow-api, workflow-registry, run records, experiment submission
- [x] `area:infra`: Kubernetes, Ansible, storage, images, rollout scripts

## Contributor checks
- [ ] I ran `./scripts/check-before-push.sh`  
- [x] I updated current docs if this changes the supported operator path.   
- [x] I marked new secondary/compatibility behavior explicitly.
- [x] I did not rely on `.44` live state unless I checked it from `.44`.  

## Live Rollout
- [ ] Not required.
- [x] Required after merge; rollout path is documented in the PR.