### PR TITLE
Add research runtime storage retention and cache cleanup (issue #99)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ __pycache__/
 *.pyo
 *.db
 .venv/
+.idea/
 kubeadm/agent-stack/12-agent-secrets.yaml
 kubeadm/glasslab-v2/secrets/*.local.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,7 @@ Per-run durable files are mounted in the orchestrator pod at:
   protocol/
   beaker-worktree/
   honeydew-worktree/
+  shared-artifacts/
   reports/
   events/
   runtime/beaker/
@@ -208,6 +209,33 @@ Per-run durable files are mounted in the orchestrator pod at:
 
 The shared PVC is backed by NFS. Inspect workspaces through the pod rather than
 assuming that path exists on the provisioner's local filesystem.
+
+`protocol/`, `reports/`, `shared-artifacts/`, and `events/` hold durable,
+artifact- and report-referenced material and are never touched by cleanup.
+`beaker-worktree/`, `honeydew-worktree/`, and `runtime/<agent>/` are agent
+process scratch space (git worktrees, OpenCode/Hermes session state and
+logs); nothing in the run/artifact database ever references a path inside
+them. OpenCode's own package/model download cache lives outside the per-run
+tree entirely, at the shared `opencode_shared_cache_root` (one copy for every
+run and both agents, since it is the same OpenCode version and plugin set
+each time) rather than being copied per run.
+
+Once a run reaches a terminal state (`COMPLETE`, `FAILED`, `CANCELLED`,
+`TIMED_OUT`) its scratch space is eligible for cleanup after
+`terminal_run_retention_days` (default 14). Run it manually from the
+orchestrator pod or a workstation with the same `GLASSLAB_ORCHESTRATOR_*`
+settings:
+
+```bash
+python services/research-orchestrator/scripts/cleanup-run-storage.py
+python services/research-orchestrator/scripts/cleanup-run-storage.py --apply
+```
+
+The default (and `--dry-run`) only reports what would be freed; `--apply` is
+required to actually delete anything. See
+`services/research-orchestrator/app/storage_retention.py` for the full
+safety design, including the per-subdirectory check against live artifact
+records applied immediately before every deletion.
 
 ## Development And Delivery
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -112,6 +112,13 @@ evaluation, report, and final acceptance.
   in #99).
 - A generic arbitrary-dataset run has not yet completed end to end (tracked
   in #98).
+- OpenCode's package/model cache is now shared across runs instead of
+  copied per run, and terminal-run scratch space (worktrees, runtime/) is
+  eligible for cleanup after `terminal_run_retention_days`; see
+  `services/research-orchestrator/scripts/cleanup-run-storage.py`. Hermes's
+  own runtime storage does not yet have the same cache-sharing treatment
+  (its on-disk layout under `HERMES_HOME` is not cleanly split into
+  cache/data/state the way OpenCode's is), only cleanup.
 
 Update this file whenever the active deployment, current blocker, or next legal
 workflow step materially changes. Keep historical detail in dated docs or run

--- a/kubeadm/glasslab-v2/research-orchestrator/10-configmap.yaml
+++ b/kubeadm/glasslab-v2/research-orchestrator/10-configmap.yaml
@@ -10,6 +10,10 @@ data:
   GLASSLAB_ORCHESTRATOR_DATABASE_PATH: /mnt/artifacts/research-orchestrator/state/orchestrator.db
   GLASSLAB_ORCHESTRATOR_WORKSPACE_ROOT: /mnt/artifacts/research-orchestrator/runs
   GLASSLAB_ORCHESTRATOR_ARTIFACT_ROOT: /mnt/artifacts/research-orchestrator/artifacts
+  # scripts/cleanup-run-storage.py eligibility window for a terminal run's
+  # worktree/runtime scratch space; protocol/reports/shared-artifacts/events
+  # are never affected regardless of this setting.
+  GLASSLAB_ORCHESTRATOR_TERMINAL_RUN_RETENTION_DAYS: "14"
   GLASSLAB_ORCHESTRATOR_EVIDENCE_EXCERPT_MAX_BYTES: "32768"
   GLASSLAB_ORCHESTRATOR_APPROVED_REPO_PATH: /mnt/artifacts/research-orchestrator/approved-repo
   GLASSLAB_ORCHESTRATOR_APPROVED_REPO_REF: main
@@ -37,6 +41,10 @@ data:
   GLASSLAB_ORCHESTRATOR_OPENCODE_REPEATED_TOOL_LIMIT: "6"
   GLASSLAB_ORCHESTRATOR_OPENCODE_STRUCTURED_REPAIR_ATTEMPTS: "1"
   GLASSLAB_ORCHESTRATOR_OPENCODE_STRUCTURED_OUTPUT_MODE: prompt
+  # One shared package/model download cache for every run and both agents
+  # instead of a copy per run (see issue #99); session/auth/log state stays
+  # per-run regardless of this setting.
+  GLASSLAB_ORCHESTRATOR_OPENCODE_SHARED_CACHE_ROOT: /mnt/artifacts/research-orchestrator/opencode-cache
   # OpenCode remains installed only as a rollback runtime.
   GLASSLAB_ORCHESTRATOR_AGENT_MODEL_PROVIDER_ID: exo
   GLASSLAB_ORCHESTRATOR_AGENT_MODEL_NAME: mlx-community/Qwen3-Coder-Next-4bit

--- a/services/research-orchestrator/app/config.py
+++ b/services/research-orchestrator/app/config.py
@@ -34,6 +34,12 @@ class Settings(BaseSettings):
     database_path: str = '/tmp/glasslab-research-orchestrator/orchestrator.db'
     workspace_root: str = '/tmp/glasslab-research-orchestrator/runs'
     artifact_root: str = '/tmp/glasslab-research-orchestrator/artifacts'
+    # How long a terminal (FAILED/CANCELLED/TIMED_OUT/COMPLETE) run's
+    # per-run runtime/worktree storage is kept before scripts/
+    # cleanup-run-storage.py is eligible to remove it. See
+    # app/storage_retention.py; this never affects protocol/reports/
+    # shared-artifacts, only agent process scratch space.
+    terminal_run_retention_days: int = 14
     # Knowledge store: chunk sizing and the per-turn retrieval budget bound
     # context cost regardless of model or content; the allowlist roots are the
     # only places ingestion may read from (in production these are the mounted
@@ -87,6 +93,15 @@ class Settings(BaseSettings):
     opencode_structured_repair_attempts: int = 1
     opencode_structured_output_mode: Literal['json_schema', 'prompt'] = (
         'json_schema'
+    )
+    # OpenCode's package/model download cache (XDG_CACHE_HOME) is shared
+    # across every run and both agents instead of copied per run: it is
+    # non-essential, regenerable data (the same OpenCode version and plugin
+    # set for everyone), unlike XDG_DATA_HOME (session auth) or
+    # XDG_STATE_HOME (logs/history), which stay isolated per run. See
+    # opencode_runtime.py's _write_runtime_config.
+    opencode_shared_cache_root: str = (
+        '/tmp/glasslab-research-orchestrator/opencode-cache'
     )
     agent_model_provider_id: str = 'exo'
     agent_model_name: str | None = None

--- a/services/research-orchestrator/app/opencode_runtime.py
+++ b/services/research-orchestrator/app/opencode_runtime.py
@@ -377,7 +377,15 @@ class OpenCodeProcessRuntime(AgentRuntime):
         runtime_root = workspace.parent / 'runtime' / agent.value
         config_root = runtime_root / 'config'
         data_root = runtime_root / 'data'
-        cache_root = runtime_root / 'cache'
+        # XDG_CACHE_HOME is intentionally NOT under runtime_root: it holds
+        # OpenCode's own package/model download cache, which is the same
+        # regenerable content for every run and both agents (same OpenCode
+        # version, same plugin set). Sharing one location here is what stops
+        # it from being copied into every run directory (see config.py's
+        # opencode_shared_cache_root and issue #99). XDG_DATA_HOME (session
+        # auth), XDG_STATE_HOME (logs/history), and HOME stay per-run: those
+        # are run-specific state, not cache.
+        cache_root = Path(self.settings.opencode_shared_cache_root)
         state_root = runtime_root / 'state'
         home_root = runtime_root / 'home'
         opencode_config_root = config_root / 'opencode'

--- a/services/research-orchestrator/app/storage_retention.py
+++ b/services/research-orchestrator/app/storage_retention.py
@@ -1,0 +1,298 @@
+"""Storage usage reporting and cleanup for terminal runs (issue #99).
+
+Scope, deliberately narrow: a run's workspace root
+(``workspace_root/<run_id>/``) holds both durable, referenced material
+(``protocol/``, ``reports/``, ``shared-artifacts/``, ``events/``) and pure
+agent-process scratch space (``beaker-worktree/``, ``honeydew-worktree/``,
+``runtime/``). Only the scratch-space subdirectories are ever eligible for
+cleanup; nothing in the database references a path inside them (artifacts
+only ever land in protocol/reports/shared-artifacts -- see
+``workspaces.copy_agent_output`` and every ``ArtifactRecord`` construction
+site in ``engine.py``). A run is only eligible once it is terminal
+(FAILED/CANCELLED/TIMED_OUT/COMPLETE) and has stayed that way for at least
+``Settings.terminal_run_retention_days``; active and paused runs are never
+touched.
+
+As a genuine runtime safety net -- not just a static code audit -- cleanup
+still cross-checks every candidate subdirectory against that run's
+``ArtifactRecord.metadata['path']`` entries before deleting anything, and
+skips (rather than deletes) any subdirectory that turns out to contain a
+referenced path. This is a report-then-act design throughout:
+``plan_cleanup`` never touches the filesystem, and both dry-run and real
+cleanup share the exact same plan so a dry run is a truthful preview.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+import os
+from pathlib import Path
+import shutil
+from typing import Any
+
+from .schemas import TERMINAL_STATES, utc_now
+from .storage import RecordNotFound
+
+# Only these subdirectories of a run's workspace root are ever eligible for
+# cleanup. protocol/, reports/, shared-artifacts/, and events/ are never
+# listed here and are never deleted by this module under any circumstance.
+CLEANABLE_SUBDIRECTORIES = ('beaker-worktree', 'honeydew-worktree', 'runtime')
+
+
+def _directory_bytes(path: Path) -> int:
+    """Sum file sizes under ``path`` without following symlinks."""
+    if not path.exists():
+        return 0
+    total = 0
+    for root, _dirs, files in os.walk(path, followlinks=False):
+        for name in files:
+            file_path = Path(root) / name
+            try:
+                total += file_path.lstat().st_size
+            except OSError:
+                # A file removed concurrently (e.g. by the running agent
+                # process) is not counted rather than failing the whole scan.
+                continue
+    return total
+
+
+@dataclass(frozen=True)
+class RunStorageUsage:
+    run_id: str
+    state: str
+    total_bytes: int
+    # Byte size of each immediate subdirectory under the run's workspace
+    # root, keyed by name (protocol, beaker-worktree, runtime, etc.).
+    subdirectory_bytes: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class StorageReport:
+    generated_at: datetime
+    total_bytes: int
+    runs: tuple[RunStorageUsage, ...]
+
+
+def report_storage_usage(
+    *,
+    store: Any,
+    workspace_root: Path,
+    now: datetime | None = None,
+) -> StorageReport:
+    """Observability for issue #99 item 5: total and per-run usage."""
+    usages: list[RunStorageUsage] = []
+    for run in store.list_runs():
+        run_root = workspace_root / run.run_id
+        if not run_root.is_dir():
+            continue
+        subdirectory_bytes = {
+            entry.name: _directory_bytes(entry)
+            for entry in sorted(run_root.iterdir())
+            if entry.is_dir() and not entry.is_symlink()
+        }
+        usages.append(
+            RunStorageUsage(
+                run_id=run.run_id,
+                state=run.state.value,
+                total_bytes=sum(subdirectory_bytes.values()),
+                subdirectory_bytes=subdirectory_bytes,
+            )
+        )
+    return StorageReport(
+        generated_at=now or utc_now(),
+        total_bytes=sum(usage.total_bytes for usage in usages),
+        runs=tuple(usages),
+    )
+
+
+def _referenced_paths(store: Any, run_id: str) -> list[Path]:
+    """Resolved filesystem paths this run's artifacts actually point at.
+
+    Only ``metadata['path']`` entries carry a real filesystem path (see the
+    module docstring); artifacts without one (or with a non-local ``uri``
+    scheme) contribute nothing here, which is safe because the presence
+    check below only ever *protects* a subdirectory, never authorizes
+    deleting one.
+    """
+    referenced: list[Path] = []
+    for artifact in store.list_artifacts(run_id):
+        raw_path = artifact.metadata.get('path')
+        if isinstance(raw_path, str) and raw_path:
+            referenced.append(Path(raw_path).resolve())
+    return referenced
+
+
+@dataclass(frozen=True)
+class SubdirectoryCleanupPlan:
+    name: str
+    path: Path
+    bytes_to_free: int
+    # None means eligible; otherwise the reason cleanup is refusing to touch
+    # this subdirectory (e.g. a referenced artifact path lives under it).
+    skip_reason: str | None = None
+
+    @property
+    def eligible(self) -> bool:
+        return self.skip_reason is None
+
+
+@dataclass(frozen=True)
+class RunCleanupPlan:
+    run_id: str
+    state: str
+    terminal_since: datetime
+    subdirectories: tuple[SubdirectoryCleanupPlan, ...]
+
+    @property
+    def eligible_bytes(self) -> int:
+        return sum(
+            item.bytes_to_free for item in self.subdirectories if item.eligible
+        )
+
+
+def plan_cleanup(
+    *,
+    store: Any,
+    workspace_root: Path,
+    retention_days: int,
+    now: datetime | None = None,
+) -> list[RunCleanupPlan]:
+    """Read-only: decide what cleanup would do, touching no filesystem state.
+
+    A run is a candidate once ``run.state in TERMINAL_STATES``. ``updated_at``
+    is used as "terminal since": every state transition (including into a
+    terminal state) sets it, and terminal states are not left once entered,
+    so nothing legitimately bumps it afterward. If that assumption is ever
+    wrong the effect is only a later cleanup, never an early one.
+    """
+    now = now or utc_now()
+    threshold = timedelta(days=retention_days)
+    plans: list[RunCleanupPlan] = []
+    for run in store.list_runs():
+        if run.state not in TERMINAL_STATES:
+            continue
+        terminal_since = run.updated_at
+        if now - terminal_since < threshold:
+            continue
+        run_root = workspace_root / run.run_id
+        referenced = _referenced_paths(store, run.run_id)
+        subdirectories: list[SubdirectoryCleanupPlan] = []
+        for name in CLEANABLE_SUBDIRECTORIES:
+            candidate = run_root / name
+            if not candidate.is_dir():
+                continue
+            resolved_candidate = candidate.resolve()
+            blocking = next(
+                (
+                    path
+                    for path in referenced
+                    if path.is_relative_to(resolved_candidate)
+                ),
+                None,
+            )
+            subdirectories.append(
+                SubdirectoryCleanupPlan(
+                    name=name,
+                    path=candidate,
+                    bytes_to_free=_directory_bytes(candidate),
+                    skip_reason=(
+                        f'referenced by an artifact record: {blocking}'
+                        if blocking is not None
+                        else None
+                    ),
+                )
+            )
+        if subdirectories:
+            plans.append(
+                RunCleanupPlan(
+                    run_id=run.run_id,
+                    state=run.state.value,
+                    terminal_since=terminal_since,
+                    subdirectories=tuple(subdirectories),
+                )
+            )
+    return plans
+
+
+@dataclass(frozen=True)
+class CleanupReport:
+    generated_at: datetime
+    dry_run: bool
+    plans: tuple[RunCleanupPlan, ...]
+    usage_before: StorageReport
+    # None in dry-run mode: nothing was deleted, so a post-cleanup usage
+    # report would be identical to usage_before and is not worth recomputing
+    # (this can be a slow full-tree walk on NFS).
+    usage_after: StorageReport | None
+
+    @property
+    def bytes_freed(self) -> int:
+        return sum(plan.eligible_bytes for plan in self.plans)
+
+
+def run_cleanup(
+    *,
+    store: Any,
+    workspace_root: Path,
+    retention_days: int,
+    dry_run: bool,
+    now: datetime | None = None,
+) -> CleanupReport:
+    """Report storage usage, plan cleanup, and (unless dry_run) apply it.
+
+    dry_run and a real run share the identical plan_cleanup() output, so a
+    dry run is a truthful preview of exactly what a real run would remove --
+    it is never a separate, looser code path.
+    """
+    now = now or utc_now()
+    usage_before = report_storage_usage(
+        store=store,
+        workspace_root=workspace_root,
+        now=now,
+    )
+    plans = plan_cleanup(
+        store=store,
+        workspace_root=workspace_root,
+        retention_days=retention_days,
+        now=now,
+    )
+    if dry_run:
+        return CleanupReport(
+            generated_at=now,
+            dry_run=True,
+            plans=tuple(plans),
+            usage_before=usage_before,
+            usage_after=None,
+        )
+
+    for plan in plans:
+        # Re-fetch the run immediately before deleting: if it somehow left
+        # terminal state (or vanished) between planning and now, skip it
+        # rather than delete storage out from under an active run. This is
+        # cheap insurance against a plan going stale during a long scan.
+        try:
+            current = store.get_run(plan.run_id)
+        except RecordNotFound:
+            continue
+        if current.state not in TERMINAL_STATES:
+            continue
+        for item in plan.subdirectories:
+            if not item.eligible:
+                continue
+            if item.path.is_symlink() or not item.path.is_dir():
+                continue
+            shutil.rmtree(item.path, ignore_errors=False)
+
+    usage_after = report_storage_usage(
+        store=store,
+        workspace_root=workspace_root,
+        now=utc_now(),
+    )
+    return CleanupReport(
+        generated_at=now,
+        dry_run=False,
+        plans=tuple(plans),
+        usage_before=usage_before,
+        usage_after=usage_after,
+    )

--- a/services/research-orchestrator/scripts/cleanup-run-storage.py
+++ b/services/research-orchestrator/scripts/cleanup-run-storage.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Report storage usage and clean up terminal-run scratch space (issue #99).
+
+Only ever deletes beaker-worktree/, honeydew-worktree/, and runtime/ under a
+run's workspace root, and only for runs that are terminal
+(FAILED/CANCELLED/TIMED_OUT/COMPLETE) and have stayed that way for at least
+the configured retention window. protocol/, reports/, shared-artifacts/, and
+events/ are never touched. See app/storage_retention.py for the full safety
+design, including the per-subdirectory artifact-reference check applied
+immediately before every deletion.
+
+Safe by default: with no flags (or with --dry-run) this only reports what
+WOULD be removed. Pass --apply to actually delete, mirroring
+import-sqlite-store-to-postgres.py's convention for destructive maintenance
+scripts.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+# When invoked as ``python scripts/...``, Python puts ``scripts`` rather than
+# the service root on sys.path. Resolve the adjacent app package explicitly so
+# the image-bundled operational tool works from any current directory.
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from app.config import Settings, get_settings
+from app.postgres_store import PostgresStore
+from app.storage import SqliteStore
+from app.storage_retention import CleanupReport, StorageReport, run_cleanup
+
+
+def _store(settings: Settings):
+    return (
+        PostgresStore(settings.store_postgres_dsn)
+        if settings.store_backend == 'postgres'
+        else SqliteStore(settings.database_path)
+    )
+
+
+def _human_bytes(count: int) -> str:
+    value = float(count)
+    for unit in ('B', 'KiB', 'MiB', 'GiB', 'TiB'):
+        if value < 1024 or unit == 'TiB':
+            return f'{value:.1f} {unit}'
+        value /= 1024
+    return f'{value:.1f} TiB'
+
+
+def _print_usage(report: StorageReport, *, label: str) -> None:
+    print(f'{label}: {_human_bytes(report.total_bytes)} across {len(report.runs)} run(s)')
+    for usage in sorted(report.runs, key=lambda item: item.total_bytes, reverse=True):
+        breakdown = ', '.join(
+            f'{name}={_human_bytes(size)}'
+            for name, size in sorted(usage.subdirectory_bytes.items())
+            if size
+        )
+        print(
+            f'  {usage.run_id} [{usage.state}]: '
+            f'{_human_bytes(usage.total_bytes)}'
+            + (f' ({breakdown})' if breakdown else '')
+        )
+
+
+def _print_report(report: CleanupReport) -> None:
+    mode = 'DRY RUN (nothing was deleted)' if report.dry_run else 'APPLIED'
+    print(f'=== Cleanup report: {mode} ===')
+    _print_usage(report.usage_before, label='Storage before')
+    print()
+
+    if not report.plans:
+        print('No terminal runs are past the retention window.')
+    for plan in report.plans:
+        print(
+            f'{plan.run_id} [{plan.state}], terminal since '
+            f'{plan.terminal_since.isoformat()}:'
+        )
+        for item in plan.subdirectories:
+            verb = 'would free' if report.dry_run else 'freed'
+            if item.eligible:
+                print(f'  - {item.name}: {verb} {_human_bytes(item.bytes_to_free)}')
+            else:
+                print(f'  - {item.name}: SKIPPED ({item.skip_reason})')
+
+    print()
+    verb = 'Would free' if report.dry_run else 'Freed'
+    print(f'{verb} {_human_bytes(report.bytes_freed)} total.')
+    if report.usage_after is not None:
+        print()
+        _print_usage(report.usage_after, label='Storage after')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--retention-days',
+        type=int,
+        default=None,
+        help=(
+            'Override Settings.terminal_run_retention_days '
+            '(GLASSLAB_ORCHESTRATOR_TERMINAL_RUN_RETENTION_DAYS).'
+        ),
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Report what would be deleted. This is also the default.',
+    )
+    parser.add_argument(
+        '--apply',
+        action='store_true',
+        help='Actually delete eligible storage. Overrides the safe default.',
+    )
+    args = parser.parse_args()
+
+    if args.dry_run and args.apply:
+        parser.error('--dry-run and --apply are mutually exclusive')
+
+    settings = get_settings()
+    retention_days = (
+        args.retention_days
+        if args.retention_days is not None
+        else settings.terminal_run_retention_days
+    )
+
+    report = run_cleanup(
+        store=_store(settings),
+        workspace_root=Path(settings.workspace_root),
+        retention_days=retention_days,
+        dry_run=not args.apply,
+    )
+    _print_report(report)
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f'cleanup failed: {exc}', file=sys.stderr)
+        raise SystemExit(1)

--- a/services/research-orchestrator/tests/test_discord_and_opencode.py
+++ b/services/research-orchestrator/tests/test_discord_and_opencode.py
@@ -798,25 +798,65 @@ def test_discord_failed_run_includes_authoritative_cause() -> None:
 def test_opencode_writable_runtime_directories_are_per_agent(
     tmp_path,
 ) -> None:
-    runtime = OpenCodeProcessRuntime(Settings())
+    # config/data/state/home are session-specific (auth, logs, conversation
+    # state) and must stay isolated per run; only the package/model download
+    # cache (see the next test) is intentionally shared.
+    runtime = OpenCodeProcessRuntime(
+        Settings(opencode_shared_cache_root=str(tmp_path / 'shared-cache'))
+    )
     workspace = tmp_path / 'run-1' / 'honeydew-worktree'
     workspace.mkdir(parents=True)
 
-    roots = runtime._write_runtime_config(
-        run_id='run-1',
-        agent=AgentName.HONEYDEW,
-        workspace=workspace,
+    config_root, data_root, cache_root, state_root, home_root = (
+        runtime._write_runtime_config(
+            run_id='run-1',
+            agent=AgentName.HONEYDEW,
+            workspace=workspace,
+        )
     )
 
-    assert all(path.is_dir() for path in roots)
-    assert all(path.is_relative_to(tmp_path / 'run-1') for path in roots)
-    config = json.loads((roots[0] / 'opencode' / 'opencode.json').read_text())
+    per_run_roots = (config_root, data_root, state_root, home_root)
+    assert all(path.is_dir() for path in per_run_roots)
+    assert all(path.is_relative_to(tmp_path / 'run-1') for path in per_run_roots)
+    assert cache_root.is_dir()
+    assert not cache_root.is_relative_to(tmp_path / 'run-1')
+    config = json.loads((config_root / 'opencode' / 'opencode.json').read_text())
     assert config['lsp'] is False
     assert config['permission']['task'] == 'deny'
     assert config['permission']['websearch'] == 'deny'
     assert config['permission']['external_directory'] == 'deny'
     assert config['model'].startswith('exo/')
     assert 'exo' in config['provider']
+
+
+def test_opencode_cache_directory_is_shared_across_runs_and_agents(
+    tmp_path,
+) -> None:
+    shared_cache = tmp_path / 'shared-cache'
+    runtime = OpenCodeProcessRuntime(
+        Settings(opencode_shared_cache_root=str(shared_cache))
+    )
+
+    roots = {}
+    for run_id, agent in (
+        ('run-1', AgentName.HONEYDEW),
+        ('run-1', AgentName.BEAKER),
+        ('run-2', AgentName.HONEYDEW),
+    ):
+        workspace = tmp_path / run_id / f'{agent.value}-worktree'
+        workspace.mkdir(parents=True)
+        _, _, cache_root, _, _ = runtime._write_runtime_config(
+            run_id=run_id,
+            agent=agent,
+            workspace=workspace,
+        )
+        roots[(run_id, agent)] = cache_root
+
+    # Every run and agent resolves to the exact same cache directory: the
+    # whole point is that OpenCode's package/model downloads are fetched
+    # once, not once per run.
+    assert len(set(roots.values())) == 1
+    assert next(iter(roots.values())) == shared_cache
 
 
 def test_opencode_uses_builtin_zen_provider_for_big_pickle(tmp_path) -> None:

--- a/services/research-orchestrator/tests/test_storage_retention.py
+++ b/services/research-orchestrator/tests/test_storage_retention.py
@@ -1,0 +1,318 @@
+"""Storage usage reporting and terminal-run cleanup (issue #99).
+
+Uses lightweight fake stores (not the full orchestrator_bundle fixture)
+because these tests need exact control over RunRecord.updated_at to place
+runs precisely inside/outside the retention window; the real store always
+overwrites updated_at with the current time on every write (see
+SqliteStore.replace_run), which makes backdating impossible through the
+public API.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from app.schemas import ArtifactRecord, RunRecord, RunState, utc_now
+from app.storage import RecordNotFound
+from app.storage_retention import (
+    CLEANABLE_SUBDIRECTORIES,
+    plan_cleanup,
+    report_storage_usage,
+    run_cleanup,
+)
+
+
+class _FakeStore:
+    def __init__(self, runs, artifacts=None):
+        self._runs = {run.run_id: run for run in runs}
+        self._artifacts = artifacts or {}
+
+    def list_runs(self):
+        return list(self._runs.values())
+
+    def list_artifacts(self, run_id):
+        return self._artifacts.get(run_id, [])
+
+    def get_run(self, run_id):
+        try:
+            return self._runs[run_id]
+        except KeyError:
+            raise RecordNotFound(run_id) from None
+
+
+def _run_record(run_id: str, *, state: RunState, updated_at) -> RunRecord:
+    now = utc_now()
+    return RunRecord(
+        run_id=run_id,
+        objective='Exercise storage retention for issue #99.',
+        state=state,
+        evaluation_contract_id='contract-1',
+        evaluation_contract_version='1.0.0',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace=f'/tmp/{run_id}/beaker-worktree',
+        honeydew_workspace=f'/tmp/{run_id}/honeydew-worktree',
+        shared_artifacts_path=f'/tmp/{run_id}/shared-artifacts',
+        reports_path=f'/tmp/{run_id}/reports',
+        maximum_turns=20,
+        maximum_runtime_seconds=86400,
+        maximum_parallel_jobs=1,
+        created_at=now,
+        updated_at=updated_at,
+    )
+
+
+def _artifact(run_id: str, *, path: str) -> ArtifactRecord:
+    return ArtifactRecord(
+        run_id=run_id,
+        type='report',
+        uri=f'artifact://{run_id}/reports/report.md',
+        sha256='b' * 64,
+        metadata={'path': path},
+    )
+
+
+def _write(path, size_bytes: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b'x' * size_bytes)
+
+
+def test_report_storage_usage_sums_subdirectories_per_run(tmp_path) -> None:
+    run = _run_record('run-1', state=RunState.COMPLETE, updated_at=utc_now())
+    _write(tmp_path / 'run-1' / 'runtime' / 'a.bin', 100)
+    _write(tmp_path / 'run-1' / 'runtime' / 'nested' / 'b.bin', 50)
+    _write(tmp_path / 'run-1' / 'protocol' / 'program.md', 25)
+
+    report = report_storage_usage(
+        store=_FakeStore([run]),
+        workspace_root=tmp_path,
+    )
+
+    assert report.total_bytes == 175
+    assert len(report.runs) == 1
+    usage = report.runs[0]
+    assert usage.run_id == 'run-1'
+    assert usage.total_bytes == 175
+    assert usage.subdirectory_bytes == {'runtime': 150, 'protocol': 25}
+
+
+def test_report_storage_usage_skips_runs_without_a_workspace_directory(
+    tmp_path,
+) -> None:
+    run = _run_record('run-missing', state=RunState.COMPLETE, updated_at=utc_now())
+
+    report = report_storage_usage(store=_FakeStore([run]), workspace_root=tmp_path)
+
+    assert report.total_bytes == 0
+    assert report.runs == ()
+
+
+def test_plan_cleanup_only_includes_terminal_runs_past_retention(
+    tmp_path,
+) -> None:
+    now = utc_now()
+    active = _run_record(
+        'run-active', state=RunState.BEAKER_IMPLEMENTING, updated_at=now - timedelta(days=90)
+    )
+    recently_terminal = _run_record(
+        'run-recent', state=RunState.COMPLETE, updated_at=now - timedelta(days=1)
+    )
+    expired_terminal = _run_record(
+        'run-expired', state=RunState.FAILED, updated_at=now - timedelta(days=30)
+    )
+    for run_id in ('run-active', 'run-recent', 'run-expired'):
+        _write(tmp_path / run_id / 'runtime' / 'cache.bin', 10)
+
+    plans = plan_cleanup(
+        store=_FakeStore([active, recently_terminal, expired_terminal]),
+        workspace_root=tmp_path,
+        retention_days=14,
+        now=now,
+    )
+
+    assert [plan.run_id for plan in plans] == ['run-expired']
+
+
+def test_plan_cleanup_never_proposes_durable_subdirectories(tmp_path) -> None:
+    now = utc_now()
+    run = _run_record('run-1', state=RunState.COMPLETE, updated_at=now - timedelta(days=30))
+    for name in (
+        'protocol',
+        'reports',
+        'shared-artifacts',
+        'events',
+        'beaker-worktree',
+        'honeydew-worktree',
+        'runtime',
+    ):
+        _write(tmp_path / 'run-1' / name / 'file.bin', 10)
+
+    plans = plan_cleanup(
+        store=_FakeStore([run]),
+        workspace_root=tmp_path,
+        retention_days=14,
+        now=now,
+    )
+
+    assert len(plans) == 1
+    proposed_names = {item.name for item in plans[0].subdirectories}
+    assert proposed_names == set(CLEANABLE_SUBDIRECTORIES)
+    assert 'protocol' not in proposed_names
+    assert 'reports' not in proposed_names
+    assert 'shared-artifacts' not in proposed_names
+    assert 'events' not in proposed_names
+
+
+def test_plan_cleanup_skips_subdirectory_referenced_by_an_artifact(
+    tmp_path,
+) -> None:
+    now = utc_now()
+    run = _run_record('run-1', state=RunState.COMPLETE, updated_at=now - timedelta(days=30))
+    referenced_file = tmp_path / 'run-1' / 'runtime' / 'beaker' / 'unexpected.txt'
+    _write(referenced_file, 10)
+    _write(tmp_path / 'run-1' / 'beaker-worktree' / 'scratch.txt', 20)
+    artifacts = {'run-1': [_artifact('run-1', path=str(referenced_file))]}
+
+    plans = plan_cleanup(
+        store=_FakeStore([run], artifacts),
+        workspace_root=tmp_path,
+        retention_days=14,
+        now=now,
+    )
+
+    assert len(plans) == 1
+    by_name = {item.name: item for item in plans[0].subdirectories}
+    assert by_name['runtime'].eligible is False
+    assert 'referenced by an artifact record' in by_name['runtime'].skip_reason
+    # An unrelated subdirectory with no referenced artifact is unaffected.
+    assert by_name['beaker-worktree'].eligible is True
+    assert plans[0].eligible_bytes == by_name['beaker-worktree'].bytes_to_free
+
+
+def test_run_cleanup_dry_run_deletes_nothing(tmp_path) -> None:
+    now = utc_now()
+    run = _run_record('run-1', state=RunState.COMPLETE, updated_at=now - timedelta(days=30))
+    target = tmp_path / 'run-1' / 'runtime' / 'beaker' / 'cache.bin'
+    _write(target, 100)
+
+    report = run_cleanup(
+        store=_FakeStore([run]),
+        workspace_root=tmp_path,
+        retention_days=14,
+        dry_run=True,
+        now=now,
+    )
+
+    assert report.dry_run is True
+    assert report.usage_after is None
+    assert report.bytes_freed == 100
+    assert target.is_file()
+
+
+def test_run_cleanup_apply_deletes_eligible_subdirectories_only(tmp_path) -> None:
+    now = utc_now()
+    run = _run_record('run-1', state=RunState.COMPLETE, updated_at=now - timedelta(days=30))
+    runtime_file = tmp_path / 'run-1' / 'runtime' / 'beaker' / 'cache.bin'
+    worktree_file = tmp_path / 'run-1' / 'beaker-worktree' / 'scratch.py'
+    protocol_file = tmp_path / 'run-1' / 'protocol' / 'program.md'
+    _write(runtime_file, 100)
+    _write(worktree_file, 50)
+    _write(protocol_file, 25)
+
+    report = run_cleanup(
+        store=_FakeStore([run]),
+        workspace_root=tmp_path,
+        retention_days=14,
+        dry_run=False,
+        now=now,
+    )
+
+    assert report.dry_run is False
+    assert report.bytes_freed == 150
+    assert not runtime_file.exists()
+    assert not worktree_file.exists()
+    assert protocol_file.is_file(), 'durable protocol/ must never be deleted'
+    assert report.usage_after is not None
+    assert report.usage_after.total_bytes == 25
+
+
+def test_run_cleanup_apply_never_touches_active_run_storage(tmp_path) -> None:
+    now = utc_now()
+    active = _run_record(
+        'run-active',
+        state=RunState.HONEYDEW_VERIFYING,
+        updated_at=now - timedelta(days=365),
+    )
+    runtime_file = tmp_path / 'run-active' / 'runtime' / 'honeydew' / 'cache.bin'
+    _write(runtime_file, 100)
+
+    report = run_cleanup(
+        store=_FakeStore([active]),
+        workspace_root=tmp_path,
+        retention_days=14,
+        dry_run=False,
+        now=now,
+    )
+
+    assert report.plans == ()
+    assert report.bytes_freed == 0
+    assert runtime_file.is_file()
+
+
+def test_run_cleanup_apply_skips_run_that_left_terminal_state_mid_scan(
+    tmp_path,
+) -> None:
+    # Regression guard for the re-fetch-before-delete race check: plan_cleanup
+    # sees the run as terminal, but by the time cleanup gets to deleting it
+    # the store reports it resumed (e.g. a rare recovery path). The stored
+    # storage must survive.
+    now = utc_now()
+    terminal_snapshot = _run_record(
+        'run-1', state=RunState.FAILED, updated_at=now - timedelta(days=30)
+    )
+    resumed_snapshot = terminal_snapshot.model_copy(
+        update={'state': RunState.BEAKER_REVISING}
+    )
+    runtime_file = tmp_path / 'run-1' / 'runtime' / 'beaker' / 'cache.bin'
+    _write(runtime_file, 100)
+
+    store = _FakeStore([terminal_snapshot])
+    # list_runs() (used for planning) still sees the terminal snapshot;
+    # get_run() (used for the pre-delete guard) reports the resumed state.
+    store.get_run = lambda run_id: resumed_snapshot  # type: ignore[method-assign]
+
+    report = run_cleanup(
+        store=store,
+        workspace_root=tmp_path,
+        retention_days=14,
+        dry_run=False,
+        now=now,
+    )
+
+    assert len(report.plans) == 1, 'planning still reports it as a candidate'
+    assert runtime_file.is_file(), 'the guard must have refused the deletion'
+
+
+def test_run_cleanup_apply_skips_run_removed_mid_scan(tmp_path) -> None:
+    now = utc_now()
+    terminal_snapshot = _run_record(
+        'run-1', state=RunState.FAILED, updated_at=now - timedelta(days=30)
+    )
+    runtime_file = tmp_path / 'run-1' / 'runtime' / 'beaker' / 'cache.bin'
+    _write(runtime_file, 100)
+
+    store = _FakeStore([terminal_snapshot])
+
+    def _missing_get_run(run_id):
+        raise RecordNotFound(run_id)
+
+    store.get_run = _missing_get_run  # type: ignore[method-assign]
+
+    report = run_cleanup(
+        store=store,
+        workspace_root=tmp_path,
+        retention_days=14,
+        dry_run=False,
+        now=now,
+    )
+
+    assert runtime_file.is_file()


### PR DESCRIPTION
Closes #99

## Scope

- [x] `area:core`: workflow-api, workflow-registry, run records, experiment submission
- [x] `area:infra`: Kubernetes, Ansible, storage, images, rollout scripts

## Contributor Checks

- [ ] I ran `./scripts/check-before-push.sh`   ← still didn't run this specific script
- [x] I updated current docs if this changes the supported operator path.
- [x] I marked new secondary/compatibility behavior explicitly.   ← the Hermes-not-yet-covered note counts
- [x] I did not rely on `.44` live state unless I checked it from `.44`.

## Live Rollout

- [ ] Not required.
- [x] Required after merge; rollout path is documented in the PR.

## What's here
- `app/storage_retention.py` (new) - `report_storage_usage()` and `plan_cleanup()`/`run_cleanup()`. Report-then-act design: planning never touches the filesystem; dry-run and real cleanup share the identical plan, so a dry run is a truthful preview.
- `scripts/cleanup-run-storage.py` (new) - CLI wrapper. Safe by default: dry-run unless `--apply` is explicitly passed.
- Only ever deletes `beaker-worktree/`, `honeydew-worktree/`, `runtime/` for terminal runs (FAILED/CANCELLED/TIMED_OUT/COMPLETE) past the retention window (default 14 days). `protocol/`, `reports/`, `shared-artifacts/`, `events/` are never eligible  enforced by an explicit allowlist, not a denylist.
- Before every deletion: cross-checks against that run's live `ArtifactRecord` paths (skips rather than deletes if referenced), and re-fetches the run's current state as a race guard against it leaving terminal state mid-scan.
- `opencode_runtime.py`/`config.py` - OpenCode's package/model cache (`XDG_CACHE_HOME`) is now shared across every run and both agents instead of copied per run. Session/auth/log state (`data`/`state`/`home`) stays isolated per run.
- Hermes's own runtime storage is explicitly NOT given the same cache-sharing treatment yet (its layout isn't cleanly split into cache/data/state) - noted as a real scope limitation, not silently skipped.
- `10-configmap.yaml` - wires the new retention/cache settings into the actual production deployment.
- `AGENTS.md`/`HANDOFF.md` - updated retention policy, script usage, and corrected a stale doc claim (OpenCode vs. Hermes as the live runtime, verified against the deployed configmap).
- 10 new tests covering retention windows, durable-subdirectory protection, artifact-reference skipping, dry-run vs. apply, and both race-condition guards, plus updated cache-sharing tests. Also ran a real end-to-end CLI smoke test against an actual SQLite store and filesystem tree.
- Full suite: 162 tests pass.
