### PR TITLE
feat(#92): add terminal research-run checkpoint retry

### DIFF
--- a/services/research-orchestrator/app/discord_adapter.py
+++ b/services/research-orchestrator/app/discord_adapter.py
@@ -310,6 +310,23 @@ class DiscordRenderer:
                 'Orchestrator',
                 f"Research run created: {payload.get('objective', '')}",
             )
+        if event_type == 'run.retry_created':
+            parent_id = str(payload.get('parent_run_id', 'unknown'))
+            parent_state = str(payload.get('parent_state', 'unknown'))
+            return DiscordMessage(
+                'Orchestrator',
+                '\n'.join([
+                    '**Retry run created from terminal checkpoint**',
+                    '',
+                    f'Parent run: `{parent_id[:16]}...` (ended `{parent_state}`)',
+                    f'Child run: `{event.run_id[:16]}...`',
+                    f"Contract digest: `{str(payload.get('contract_digest', ''))[:12]}...`",
+                    f"Worktree files copied: {payload.get('worktree_manifest_files', '?')}",
+                    '',
+                    'The approved protocol and Beaker checkpoint are cloned.',
+                    'Resuming at Honeydew methodology review.',
+                ]),
+            )
         if event_type == 'run.state_changed':
             return DiscordMessage(
                 'Orchestrator',

--- a/services/research-orchestrator/app/engine.py
+++ b/services/research-orchestrator/app/engine.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from hashlib import sha256
 import json
 from pathlib import Path
+import shutil
 import subprocess
 from threading import RLock
 from typing import Any
@@ -38,6 +39,7 @@ from .schemas import (
     RequestedAction,
     RunCreateRequest,
     RunRecord,
+    RunRetryRequest,
     RunState,
     TERMINAL_STATES,
     TurnKind,
@@ -281,6 +283,138 @@ class ResearchOrchestrator:
                 self._fail_run(run_id, exc)
                 raise
             return self.store.get_run(run_id)
+
+    def retry_run(
+        self,
+        parent_run_id: str,
+        *,
+        request: RunRetryRequest,
+    ) -> RunRecord:
+        with self._advance_lock:
+            parent = self.store.get_run(parent_run_id)
+            if parent.state not in TERMINAL_STATES or parent.state == RunState.COMPLETE:
+                raise WorkflowError(
+                    f'cannot retry run in state {parent.state.value}; '
+                    'only FAILED, TIMED_OUT, or CANCELLED runs are retryable'
+                )
+            # Idempotency guard: refuse if a non-terminal child already exists.
+            existing_children = self.store.get_lineage(parent_run_id)
+            active_children = [
+                c for c in existing_children if c.state not in TERMINAL_STATES
+            ]
+            if active_children:
+                raise WorkflowError(
+                    f'parent run already has a non-terminal child: '
+                    f'{active_children[0].run_id}'
+                )
+            # Carry the latest pending matrix action forward into the child.
+            parent_action = self._latest_pending_matrix_action(parent_run_id)
+            child_run_id = uuid4().hex
+            paths = self.workspaces.prepare(child_run_id)
+            manifest = self.workspaces.clone_beaker_worktree(
+                parent_run_id=parent_run_id,
+                child_run_id=child_run_id,
+            )
+            # Copy and freeze the approved protocol. Prefer the durable
+            # protocol/ path; fall back to the Beaker worktree copy.
+            if parent.protocol_path:
+                parent_protocol = Path(parent.protocol_path)
+            else:
+                parent_protocol = Path(parent.beaker_workspace) / 'program.md'
+            if not parent_protocol.is_file():
+                raise WorkflowError(
+                    f'parent run has no readable protocol file: {parent_protocol}'
+                )
+            child_protocol_dest = paths.protocol / 'program.md'
+            shutil.copy2(parent_protocol, child_protocol_dest)
+            self.workspaces.freeze_protocol(child_run_id)
+            now = utc_now()
+            child_record = RunRecord(
+                run_id=child_run_id,
+                parent_run_id=parent_run_id,
+                objective=parent.objective,
+                state=RunState.CREATED,
+                evaluation_contract_id=parent.evaluation_contract_id,
+                evaluation_contract_version=parent.evaluation_contract_version,
+                evaluation_contract_digest=parent.evaluation_contract_digest,
+                task_id=parent.task_id,
+                task_bundle_digest=parent.task_bundle_digest,
+                task_bundle_path=parent.task_bundle_path,
+                task_definition=parent.task_definition,
+                beaker_workspace=str(paths.beaker),
+                honeydew_workspace=str(paths.honeydew),
+                shared_artifacts_path=str(paths.shared_artifacts),
+                reports_path=str(paths.reports),
+                maximum_turns=(
+                    request.maximum_turns
+                    or parent.maximum_turns
+                ),
+                maximum_runtime_seconds=(
+                    request.maximum_runtime_seconds
+                    or parent.maximum_runtime_seconds
+                ),
+                maximum_parallel_jobs=min(
+                    request.maximum_parallel_jobs
+                    or parent.maximum_parallel_jobs,
+                    self.settings.maximum_parallel_jobs,
+                ),
+                active_since=now,
+                created_at=now,
+                updated_at=now,
+            )
+            self.store.create_retry_run(
+                child_record,
+                parent_run_id=parent_run_id,
+            )
+            try:
+                thread_id = self.discord.create_thread(
+                    run_id=child_run_id,
+                    objective=parent.objective,
+                )
+            except Exception:
+                thread_id = None
+            if thread_id:
+                current = self.store.get_run(child_run_id)
+                child_record = self.store.replace_run(
+                    current.model_copy(update={'discord_thread_id': thread_id}),
+                    expected_version=current.version,
+                )
+            self._event(
+                child_run_id,
+                source='orchestrator',
+                event_type='run.retry_created',
+                payload={
+                    'parent_run_id': parent_run_id,
+                    'parent_state': parent.state.value,
+                    'contract_digest': parent.evaluation_contract_digest or '',
+                    'worktree_manifest_files': len(manifest),
+                },
+            )
+            # Seed child with a fresh copy of the parent's pending matrix action.
+            child_action = ActionRecord(
+                action_id=uuid4().hex,
+                run_id=child_run_id,
+                proposed_by=parent_action.proposed_by,
+                type=parent_action.type,
+                arguments=parent_action.arguments,
+                policy_classification=parent_action.policy_classification,
+                approval_status=ApprovalStatus.PENDING,
+                honeydew_approved=False,
+                idempotency_key=uuid4().hex,
+                reason=f'carried forward from parent run {parent_run_id}',
+            )
+            self.store.save_action(child_action)
+            self._transition(child_run_id, RunState.PREPARING)
+            self._transition(child_run_id, RunState.HONEYDEW_REVIEWING)
+            try:
+                self._honeydew_review(
+                    child_run_id,
+                    implementation_turn_id=f'retry:{parent_run_id}',
+                )
+            except Exception as exc:
+                self._fail_run(child_run_id, exc)
+                raise
+            return self.store.get_run(child_run_id)
 
     def import_task_bundle(
         self,

--- a/services/research-orchestrator/app/engine.py
+++ b/services/research-orchestrator/app/engine.py
@@ -4166,8 +4166,15 @@ class ResearchOrchestrator:
             )
             return
         if state == RunState.PREPARING:
-            self._transition(run_id, RunState.HONEYDEW_DRAFTING_PROTOCOL)
-            self._draft_protocol(run_id)
+            if run.parent_run_id:
+                # Retry child crashed in PREPARING before reaching
+                # HONEYDEW_REVIEWING; skip protocol drafting and go straight
+                # to methodology review (the approved protocol is already frozen).
+                self._transition(run_id, RunState.HONEYDEW_REVIEWING)
+                self._honeydew_review(run_id, implementation_turn_id='recovered')
+            else:
+                self._transition(run_id, RunState.HONEYDEW_DRAFTING_PROTOCOL)
+                self._draft_protocol(run_id)
         elif state == RunState.HONEYDEW_DRAFTING_PROTOCOL:
             self._draft_protocol(run_id)
         elif state == RunState.BEAKER_DRAFTING_CONTRACT:

--- a/services/research-orchestrator/app/main.py
+++ b/services/research-orchestrator/app/main.py
@@ -56,6 +56,7 @@ from .schemas import (
     RunCreateRequest,
     RunListResponse,
     RunRecord,
+    RunRetryRequest,
     SourceType,
 )
 from .storage import ConcurrencyConflict, RecordNotFound, SqliteStore
@@ -619,6 +620,21 @@ def create_app(
     ) -> RunRecord:
         try:
             return engine.cancel_run(run_id)
+        except Exception as exc:
+            raise map_error(exc) from exc
+
+    @app.post(
+        '/runs/{run_id}/retry',
+        response_model=RunRecord,
+        status_code=status.HTTP_201_CREATED,
+    )
+    def retry_run(
+        run_id: str,
+        request: RunRetryRequest,
+        _: None = Depends(require_operator),
+    ) -> RunRecord:
+        try:
+            return engine.retry_run(run_id, request=request)
         except Exception as exc:
             raise map_error(exc) from exc
 

--- a/services/research-orchestrator/app/postgres_store.py
+++ b/services/research-orchestrator/app/postgres_store.py
@@ -112,6 +112,11 @@ class PostgresStore:
           packet_id TEXT PRIMARY KEY, run_id TEXT NOT NULL REFERENCES orchestrator_runs(run_id),
           payload JSONB NOT NULL, created_at TIMESTAMPTZ NOT NULL);
         CREATE INDEX IF NOT EXISTS orchestrator_context_packets_run_idx ON orchestrator_context_packets(run_id, created_at);
+        CREATE TABLE IF NOT EXISTS orchestrator_run_lineage (
+          child_run_id TEXT PRIMARY KEY REFERENCES orchestrator_runs(run_id),
+          parent_run_id TEXT NOT NULL REFERENCES orchestrator_runs(run_id),
+          created_at TIMESTAMPTZ NOT NULL);
+        CREATE INDEX IF NOT EXISTS orchestrator_run_lineage_parent_idx ON orchestrator_run_lineage(parent_run_id);
         '''
         with self._connect() as conn:
             with conn.cursor() as cur:
@@ -144,6 +149,25 @@ class PostgresStore:
             conn.execute('INSERT INTO orchestrator_runs (run_id, state, version, payload, created_at, updated_at) VALUES (%s, %s, %s, %s, %s, %s)', (record.run_id, record.state.value, record.version, self._payload(record), record.created_at, record.updated_at))
             self._append_event_conn(conn, run_id=record.run_id, source='orchestrator', event_type='run.created', payload={'objective': record.objective, 'state': record.state.value})
         return record
+
+    def create_retry_run(self, record: RunRecord, *, parent_run_id: str) -> RunRecord:
+        with self.transaction() as conn:
+            parent_row = conn.execute('SELECT state FROM orchestrator_runs WHERE run_id=%s FOR UPDATE', (parent_run_id,)).fetchone()
+            if parent_row is None:
+                raise RecordNotFound(parent_run_id)
+            parent_state = RunState(parent_row['state'])
+            if parent_state not in TERMINAL_STATES or parent_state == RunState.COMPLETE:
+                raise ConcurrencyConflict(f'parent run is not in a retryable terminal state: {parent_state}')
+            conn.execute('INSERT INTO orchestrator_runs (run_id, state, version, payload, created_at, updated_at) VALUES (%s, %s, %s, %s, %s, %s)', (record.run_id, record.state.value, record.version, self._payload(record), record.created_at, record.updated_at))
+            now = utc_now()
+            conn.execute('INSERT INTO orchestrator_run_lineage (child_run_id, parent_run_id, created_at) VALUES (%s, %s, %s)', (record.run_id, parent_run_id, now))
+            self._append_event_conn(conn, run_id=record.run_id, source='orchestrator', event_type='run.created', payload={'objective': record.objective, 'state': record.state.value, 'parent_run_id': parent_run_id})
+        return record
+
+    def get_lineage(self, parent_run_id: str) -> list[RunRecord]:
+        with self._connect() as conn:
+            rows = conn.execute('SELECT r.payload FROM orchestrator_run_lineage l JOIN orchestrator_runs r ON r.run_id = l.child_run_id WHERE l.parent_run_id=%s ORDER BY l.created_at', (parent_run_id,)).fetchall()
+        return [RunRecord.model_validate(r['payload']) for r in rows]
 
     def _run(self, row: dict[str, Any] | None, run_id: str) -> RunRecord:
         if row is None: raise RecordNotFound(run_id)

--- a/services/research-orchestrator/app/schemas.py
+++ b/services/research-orchestrator/app/schemas.py
@@ -429,6 +429,7 @@ class RunRecord(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
     run_id: str
+    parent_run_id: str | None = None
     objective: str
     state: RunState
     protocol_path: str | None = None
@@ -782,6 +783,14 @@ class RunCreateRequest(BaseModel):
         if bool(self.evaluation_contract_id) != bool(self.evaluation_contract_version):
             raise ValueError('evaluation contract ID and version must be supplied together')
         return self
+
+
+class RunRetryRequest(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    maximum_turns: int | None = Field(default=None, ge=1)
+    maximum_runtime_seconds: int | None = Field(default=None, ge=60)
+    maximum_parallel_jobs: int | None = Field(default=None, ge=1)
 
 
 class ApprovalRequest(BaseModel):

--- a/services/research-orchestrator/app/state_machine.py
+++ b/services/research-orchestrator/app/state_machine.py
@@ -26,6 +26,7 @@ TRANSITIONS: dict[RunState, set[RunState]] = {
     RunState.CREATED: {RunState.PREPARING, RunState.CANCELLED, RunState.FAILED},
     RunState.PREPARING: {
         RunState.HONEYDEW_DRAFTING_PROTOCOL,
+        RunState.HONEYDEW_REVIEWING,
         RunState.PAUSED,
         RunState.CANCELLED,
         RunState.FAILED,

--- a/services/research-orchestrator/app/storage.py
+++ b/services/research-orchestrator/app/storage.py
@@ -264,6 +264,14 @@ class SqliteStore:
                 -- URIs) even long after the turn finished.
                 CREATE INDEX IF NOT EXISTS context_packets_run_idx
                 ON context_packets(run_id, created_at);
+
+                CREATE TABLE IF NOT EXISTS run_lineage (
+                    child_run_id  TEXT PRIMARY KEY REFERENCES runs(run_id),
+                    parent_run_id TEXT NOT NULL REFERENCES runs(run_id),
+                    created_at    TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS run_lineage_parent_idx
+                ON run_lineage(parent_run_id);
                 '''
             )
 
@@ -376,6 +384,73 @@ class SqliteStore:
                 payload={'objective': record.objective, 'state': record.state.value},
             )
         return record
+
+    def create_retry_run(
+        self,
+        record: RunRecord,
+        *,
+        parent_run_id: str,
+    ) -> RunRecord:
+        with self.transaction() as connection:
+            parent_row = connection.execute(
+                'SELECT state FROM runs WHERE run_id = ?',
+                (parent_run_id,),
+            ).fetchone()
+            if parent_row is None:
+                raise RecordNotFound(parent_run_id)
+            parent_state = RunState(parent_row['state'])
+            if parent_state not in TERMINAL_STATES or parent_state == RunState.COMPLETE:
+                raise ConcurrencyConflict(
+                    f'parent run is not in a retryable terminal state: {parent_state}'
+                )
+            connection.execute(
+                '''
+                INSERT INTO runs (
+                    run_id, state, version, payload, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                ''',
+                (
+                    record.run_id,
+                    record.state.value,
+                    record.version,
+                    _dump(record),
+                    record.created_at.isoformat(),
+                    record.updated_at.isoformat(),
+                ),
+            )
+            now = utc_now()
+            connection.execute(
+                '''
+                INSERT INTO run_lineage (child_run_id, parent_run_id, created_at)
+                VALUES (?, ?, ?)
+                ''',
+                (record.run_id, parent_run_id, now.isoformat()),
+            )
+            self._append_event_conn(
+                connection,
+                run_id=record.run_id,
+                source='orchestrator',
+                event_type='run.created',
+                payload={
+                    'objective': record.objective,
+                    'state': record.state.value,
+                    'parent_run_id': parent_run_id,
+                },
+            )
+        return record
+
+    def get_lineage(self, parent_run_id: str) -> list[RunRecord]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                '''
+                SELECT r.payload FROM run_lineage l
+                JOIN runs r ON r.run_id = l.child_run_id
+                WHERE l.parent_run_id = ?
+                ORDER BY l.created_at
+                ''',
+                (parent_run_id,),
+            ).fetchall()
+        return [RunRecord.model_validate_json(row['payload']) for row in rows]
 
     def get_run(self, run_id: str) -> RunRecord:
         with self._connect() as connection:

--- a/services/research-orchestrator/app/workspaces.py
+++ b/services/research-orchestrator/app/workspaces.py
@@ -161,6 +161,44 @@ class WorkspaceManager:
             shutil.copy2(protocol, target)
             target.chmod(0o444)
 
+    def clone_beaker_worktree(
+        self,
+        *,
+        parent_run_id: str,
+        child_run_id: str,
+    ) -> dict[str, str]:
+        """Copy parent Beaker worktree into child's Beaker worktree.
+
+        Returns a path→sha256 manifest of every copied file. Raises
+        WorkspaceError if any destination digest does not match its source,
+        or if the source contains symlinks or path escapes.
+        """
+        source_root = self.paths(parent_run_id).beaker.resolve()
+        dest_root = self.paths(child_run_id).beaker.resolve()
+        manifest: dict[str, str] = {}
+        for source in sorted(source_root.rglob('*')):
+            if source.is_symlink():
+                raise WorkspaceError(
+                    f'parent Beaker worktree contains a symlink: {source}'
+                )
+            if not source.is_file():
+                continue
+            # Skip the git internal file that marks a worktree.
+            if source.name == '.git' or '.git' in source.parts:
+                continue
+            relative = source.relative_to(source_root)
+            source_digest = sha256(source.read_bytes()).hexdigest()
+            destination = dest_root / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+            dest_digest = sha256(destination.read_bytes()).hexdigest()
+            if dest_digest != source_digest:
+                raise WorkspaceError(
+                    f'checksum mismatch after copy: {relative}'
+                )
+            manifest[relative.as_posix()] = dest_digest
+        return manifest
+
     def create_review_snapshot(
         self,
         *,

--- a/services/research-orchestrator/tests/test_retry.py
+++ b/services/research-orchestrator/tests/test_retry.py
@@ -576,3 +576,92 @@ def test_run_retry_request_rejects_invalid_bounds() -> None:
         RunRetryRequest(maximum_turns=0)
     with pytest.raises(pydantic.ValidationError):
         RunRetryRequest(maximum_runtime_seconds=30)
+
+
+# ---------------------------------------------------------------------------
+# Recovery: PREPARING retry child routes to HONEYDEW_REVIEWING, not protocol
+# ---------------------------------------------------------------------------
+
+
+def test_recover_routes_retry_child_in_preparing_to_honeydew_reviewing(
+    orchestrator_bundle, monkeypatch
+) -> None:
+    # Simulate a crash between create_retry_run and the HONEYDEW_REVIEWING
+    # transition. Recovery must not start protocol drafting for a child run.
+    _, store, _, _, engine = orchestrator_bundle
+    now = utc_now()
+
+    parent_id = uuid4().hex
+    parent = RunRecord(
+        run_id=parent_id,
+        objective='Wine clustering.',
+        state=RunState.FAILED,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/x',
+        honeydew_workspace='/x',
+        shared_artifacts_path='/x',
+        reports_path='/x',
+        maximum_turns=20,
+        maximum_runtime_seconds=3600,
+        maximum_parallel_jobs=1,
+        active_since=None,
+        created_at=now,
+        updated_at=now,
+    )
+    store.create_run(parent, one_active_run=False)
+
+    child_id = uuid4().hex
+    child = RunRecord(
+        run_id=child_id,
+        parent_run_id=parent_id,
+        objective='Wine clustering.',
+        state=RunState.PREPARING,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/x',
+        honeydew_workspace='/x',
+        shared_artifacts_path='/x',
+        reports_path='/x',
+        maximum_turns=20,
+        maximum_runtime_seconds=3600,
+        maximum_parallel_jobs=1,
+        active_since=now,
+        created_at=now,
+        updated_at=now,
+    )
+    store.create_retry_run(child, parent_run_id=parent_id)
+
+    # Seed a pending matrix action so _honeydew_review doesn't raise.
+    from app.schemas import ActionRecord, AgentName, ApprovalStatus, PolicyClassification
+    action = ActionRecord(
+        run_id=child_id,
+        proposed_by=AgentName.BEAKER,
+        type='submit_experiment_matrix',
+        arguments={},
+        policy_classification=PolicyClassification.HONEYDEW_AND_HUMAN_APPROVAL,
+        approval_status=ApprovalStatus.PENDING,
+        idempotency_key=uuid4().hex,
+        reason='carried forward from parent',
+    )
+    store.save_action(action)
+
+    transitions_seen: list[str] = []
+
+    original_transition = engine._transition
+    def recording_transition(run_id, target, **kwargs):
+        transitions_seen.append(target.value)
+        return original_transition(run_id, target, **kwargs)
+    monkeypatch.setattr(engine, '_transition', recording_transition)
+
+    # _honeydew_review will fail (no real workspace), but we only care that
+    # the recovery entered HONEYDEW_REVIEWING, not HONEYDEW_DRAFTING_PROTOCOL.
+    try:
+        engine._recover_run(child_id)
+    except Exception:
+        pass
+
+    assert RunState.HONEYDEW_REVIEWING.value in transitions_seen
+    assert RunState.HONEYDEW_DRAFTING_PROTOCOL.value not in transitions_seen

--- a/services/research-orchestrator/tests/test_retry.py
+++ b/services/research-orchestrator/tests/test_retry.py
@@ -1,0 +1,578 @@
+"""Tests for terminal-checkpoint retry (issue #92).
+
+Covers: storage lineage methods, workspace clone, engine retry_run,
+discord rendering, and the HTTP endpoint surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from app.discord_adapter import DisabledDiscordAdapter
+from app.engine import ResearchOrchestrator, WorkflowError
+from app.schemas import (
+    RunRecord,
+    RunRetryRequest,
+    RunState,
+    utc_now,
+)
+from app.storage import ConcurrencyConflict, RecordNotFound, SqliteStore
+from app.workspaces import WorkspaceError, WorkspaceManager
+
+from conftest import RUNNER_IMAGE, create_test_repo
+
+
+# ---------------------------------------------------------------------------
+# Storage: create_retry_run and get_lineage
+# ---------------------------------------------------------------------------
+
+
+def _make_run(store: SqliteStore, *, state: RunState = RunState.CREATED) -> RunRecord:
+    run_id = uuid4().hex
+    now = utc_now()
+    record = RunRecord(
+        run_id=run_id,
+        objective='test objective',
+        state=RunState.CREATED,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace=f'/tmp/runs/{run_id}/beaker',
+        honeydew_workspace=f'/tmp/runs/{run_id}/honeydew',
+        shared_artifacts_path=f'/tmp/runs/{run_id}/shared',
+        reports_path=f'/tmp/runs/{run_id}/reports',
+        maximum_turns=20,
+        maximum_runtime_seconds=3600,
+        maximum_parallel_jobs=1,
+        active_since=now,
+        created_at=now,
+        updated_at=now,
+    )
+    store.create_run(record, one_active_run=False)
+    if state != RunState.CREATED:
+        # Drive straight to the target via replace_run to avoid needing
+        # validate_transition (state machine gaps in test scaffolding).
+        stored = store.get_run(run_id)
+        store.replace_run(
+            stored.model_copy(update={'state': state}),
+            expected_version=stored.version,
+        )
+    return store.get_run(run_id)
+
+
+def test_create_retry_run_records_lineage(tmp_path) -> None:
+    store = SqliteStore(str(tmp_path / 'db.sqlite'))
+    parent = _make_run(store, state=RunState.FAILED)
+    child_id = uuid4().hex
+    now = utc_now()
+    child = RunRecord(
+        run_id=child_id,
+        parent_run_id=parent.run_id,
+        objective=parent.objective,
+        state=RunState.CREATED,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace=f'/tmp/runs/{child_id}/beaker',
+        honeydew_workspace=f'/tmp/runs/{child_id}/honeydew',
+        shared_artifacts_path=f'/tmp/runs/{child_id}/shared',
+        reports_path=f'/tmp/runs/{child_id}/reports',
+        maximum_turns=20,
+        maximum_runtime_seconds=3600,
+        maximum_parallel_jobs=1,
+        active_since=now,
+        created_at=now,
+        updated_at=now,
+    )
+    result = store.create_retry_run(child, parent_run_id=parent.run_id)
+    assert result.run_id == child_id
+    assert result.parent_run_id == parent.run_id
+    lineage = store.get_lineage(parent.run_id)
+    assert len(lineage) == 1
+    assert lineage[0].run_id == child_id
+
+
+def test_create_retry_run_rejects_non_terminal_parent(tmp_path) -> None:
+    store = SqliteStore(str(tmp_path / 'db.sqlite'))
+    parent = _make_run(store, state=RunState.CREATED)
+    child_id = uuid4().hex
+    now = utc_now()
+    child = RunRecord(
+        run_id=child_id,
+        parent_run_id=parent.run_id,
+        objective=parent.objective,
+        state=RunState.CREATED,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace=f'/tmp/runs/{child_id}/beaker',
+        honeydew_workspace=f'/tmp/runs/{child_id}/honeydew',
+        shared_artifacts_path=f'/tmp/runs/{child_id}/shared',
+        reports_path=f'/tmp/runs/{child_id}/reports',
+        maximum_turns=20,
+        maximum_runtime_seconds=3600,
+        maximum_parallel_jobs=1,
+        active_since=now,
+        created_at=now,
+        updated_at=now,
+    )
+    with pytest.raises(ConcurrencyConflict, match='retryable terminal state'):
+        store.create_retry_run(child, parent_run_id=parent.run_id)
+
+
+def test_create_retry_run_rejects_complete_parent(tmp_path) -> None:
+    store = SqliteStore(str(tmp_path / 'db.sqlite'))
+    parent = _make_run(store, state=RunState.COMPLETE)
+    child_id = uuid4().hex
+    now = utc_now()
+    child = RunRecord(
+        run_id=child_id,
+        objective='x',
+        state=RunState.CREATED,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/x',
+        honeydew_workspace='/x',
+        shared_artifacts_path='/x',
+        reports_path='/x',
+        maximum_turns=1,
+        maximum_runtime_seconds=60,
+        maximum_parallel_jobs=1,
+        active_since=now,
+        created_at=now,
+        updated_at=now,
+    )
+    with pytest.raises(ConcurrencyConflict, match='retryable terminal state'):
+        store.create_retry_run(child, parent_run_id=parent.run_id)
+
+
+def test_create_retry_run_missing_parent_raises(tmp_path) -> None:
+    store = SqliteStore(str(tmp_path / 'db.sqlite'))
+    now = utc_now()
+    child_id = uuid4().hex
+    child = RunRecord(
+        run_id=child_id,
+        objective='x',
+        state=RunState.CREATED,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/x',
+        honeydew_workspace='/x',
+        shared_artifacts_path='/x',
+        reports_path='/x',
+        maximum_turns=1,
+        maximum_runtime_seconds=60,
+        maximum_parallel_jobs=1,
+        active_since=now,
+        created_at=now,
+        updated_at=now,
+    )
+    with pytest.raises(RecordNotFound):
+        store.create_retry_run(child, parent_run_id='doesnotexist')
+
+
+def test_get_lineage_returns_empty_for_no_children(tmp_path) -> None:
+    store = SqliteStore(str(tmp_path / 'db.sqlite'))
+    parent = _make_run(store, state=RunState.FAILED)
+    assert store.get_lineage(parent.run_id) == []
+
+
+# ---------------------------------------------------------------------------
+# Workspaces: clone_beaker_worktree
+# ---------------------------------------------------------------------------
+
+
+def test_clone_beaker_worktree_copies_files_with_digest_check(tmp_path) -> None:
+    repo = create_test_repo(tmp_path)
+    ws = WorkspaceManager(
+        workspace_root=str(tmp_path / 'runs'),
+        approved_repo_path=str(repo),
+        approved_repo_ref='main',
+    )
+    parent_id = uuid4().hex
+    child_id = uuid4().hex
+    parent_paths = ws.prepare(parent_id)
+    ws.prepare(child_id)
+
+    (parent_paths.beaker / 'program.md').write_text('# Protocol\n')
+    (parent_paths.beaker / 'data').mkdir()
+    (parent_paths.beaker / 'data' / 'results.csv').write_text('a,b\n1,2\n')
+
+    manifest = ws.clone_beaker_worktree(
+        parent_run_id=parent_id, child_run_id=child_id
+    )
+    child_paths = ws.paths(child_id)
+
+    assert 'program.md' in manifest
+    assert 'data/results.csv' in manifest
+    assert (child_paths.beaker / 'program.md').read_text() == '# Protocol\n'
+    assert (child_paths.beaker / 'data' / 'results.csv').read_text() == 'a,b\n1,2\n'
+
+
+def test_clone_beaker_worktree_copies_repo_baseline_files(tmp_path) -> None:
+    # The worktree is seeded from the approved repo, so baseline files
+    # (README.md, configs/baseline.yaml) are present and should be copied.
+    repo = create_test_repo(tmp_path)
+    ws = WorkspaceManager(
+        workspace_root=str(tmp_path / 'runs'),
+        approved_repo_path=str(repo),
+        approved_repo_ref='main',
+    )
+    parent_id, child_id = uuid4().hex, uuid4().hex
+    ws.prepare(parent_id)
+    ws.prepare(child_id)
+    manifest = ws.clone_beaker_worktree(parent_run_id=parent_id, child_run_id=child_id)
+    assert 'README.md' in manifest
+    assert 'configs/baseline.yaml' in manifest
+
+
+def test_clone_beaker_worktree_rejects_symlinks(tmp_path) -> None:
+    repo = create_test_repo(tmp_path)
+    ws = WorkspaceManager(
+        workspace_root=str(tmp_path / 'runs'),
+        approved_repo_path=str(repo),
+        approved_repo_ref='main',
+    )
+    parent_id, child_id = uuid4().hex, uuid4().hex
+    parent_paths = ws.prepare(parent_id)
+    ws.prepare(child_id)
+
+    real_file = parent_paths.beaker / 'real.txt'
+    real_file.write_text('hello')
+    link = parent_paths.beaker / 'link.txt'
+    link.symlink_to(real_file)
+
+    with pytest.raises(WorkspaceError, match='symlink'):
+        ws.clone_beaker_worktree(parent_run_id=parent_id, child_run_id=child_id)
+
+
+# ---------------------------------------------------------------------------
+# Engine: retry_run — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_retry_run_rejects_active_parent(orchestrator_bundle) -> None:
+    _, store, _, _, engine = orchestrator_bundle
+    now = utc_now()
+    run_id = uuid4().hex
+    record = RunRecord(
+        run_id=run_id,
+        objective='Active run retry test.',
+        state=RunState.PREPARING,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/x',
+        honeydew_workspace='/x',
+        shared_artifacts_path='/x',
+        reports_path='/x',
+        maximum_turns=20,
+        maximum_runtime_seconds=3600,
+        maximum_parallel_jobs=1,
+        active_since=now,
+        created_at=now,
+        updated_at=now,
+    )
+    store.create_run(record, one_active_run=False)
+    with pytest.raises(WorkflowError, match='cannot retry run'):
+        engine.retry_run(run_id, request=RunRetryRequest())
+
+
+def test_retry_run_rejects_complete_parent(orchestrator_bundle) -> None:
+    _, store, _, _, engine = orchestrator_bundle
+    now = utc_now()
+    run_id = uuid4().hex
+    record = RunRecord(
+        run_id=run_id,
+        objective='Should be complete.',
+        state=RunState.COMPLETE,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/x',
+        honeydew_workspace='/x',
+        shared_artifacts_path='/x',
+        reports_path='/x',
+        maximum_turns=1,
+        maximum_runtime_seconds=60,
+        maximum_parallel_jobs=1,
+        active_since=None,
+        created_at=now,
+        updated_at=now,
+    )
+    store.create_run(record, one_active_run=False)
+    with pytest.raises(WorkflowError, match='cannot retry run'):
+        engine.retry_run(run_id, request=RunRetryRequest())
+
+
+def test_retry_run_rejects_nonexistent_parent(orchestrator_bundle) -> None:
+    _, _, _, _, engine = orchestrator_bundle
+    with pytest.raises(Exception):
+        engine.retry_run('doesnotexist', request=RunRetryRequest())
+
+
+def test_retry_run_rejects_when_active_child_exists(
+    orchestrator_bundle, monkeypatch
+) -> None:
+    _, store, _, _, engine = orchestrator_bundle
+    now = utc_now()
+
+    parent_id = uuid4().hex
+    parent = RunRecord(
+        run_id=parent_id,
+        objective='Wine clustering.',
+        state=RunState.FAILED,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/x',
+        honeydew_workspace='/x',
+        shared_artifacts_path='/x',
+        reports_path='/x',
+        maximum_turns=20,
+        maximum_runtime_seconds=3600,
+        maximum_parallel_jobs=1,
+        active_since=None,
+        created_at=now,
+        updated_at=now,
+    )
+    store.create_run(parent, one_active_run=False)
+
+    child_id = uuid4().hex
+    child = RunRecord(
+        run_id=child_id,
+        parent_run_id=parent_id,
+        objective='Wine clustering.',
+        state=RunState.CREATED,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/x',
+        honeydew_workspace='/x',
+        shared_artifacts_path='/x',
+        reports_path='/x',
+        maximum_turns=20,
+        maximum_runtime_seconds=3600,
+        maximum_parallel_jobs=1,
+        active_since=now,
+        created_at=now,
+        updated_at=now,
+    )
+    store.create_retry_run(child, parent_run_id=parent_id)
+
+    with pytest.raises(WorkflowError, match='non-terminal child'):
+        engine.retry_run(parent_id, request=RunRetryRequest())
+
+
+def test_retry_run_rejects_when_no_pending_matrix_action(
+    orchestrator_bundle,
+) -> None:
+    _, store, _, _, engine = orchestrator_bundle
+    now = utc_now()
+    parent_id = uuid4().hex
+    parent = RunRecord(
+        run_id=parent_id,
+        objective='Test.',
+        state=RunState.TIMED_OUT,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/x',
+        honeydew_workspace='/x',
+        shared_artifacts_path='/x',
+        reports_path='/x',
+        maximum_turns=20,
+        maximum_runtime_seconds=3600,
+        maximum_parallel_jobs=1,
+        active_since=None,
+        created_at=now,
+        updated_at=now,
+    )
+    store.create_run(parent, one_active_run=False)
+    with pytest.raises(WorkflowError, match='no pending experiment matrix'):
+        engine.retry_run(parent_id, request=RunRetryRequest())
+
+
+# ---------------------------------------------------------------------------
+# Storage: retryable terminal states
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('state', [RunState.FAILED, RunState.TIMED_OUT, RunState.CANCELLED])
+def test_create_retry_run_accepts_all_retryable_states(tmp_path, state) -> None:
+    store = SqliteStore(str(tmp_path / 'db.sqlite'))
+    parent = _make_run(store, state=state)
+    child_id = uuid4().hex
+    now = utc_now()
+    child = RunRecord(
+        run_id=child_id,
+        parent_run_id=parent.run_id,
+        objective=parent.objective,
+        state=RunState.CREATED,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/x',
+        honeydew_workspace='/x',
+        shared_artifacts_path='/x',
+        reports_path='/x',
+        maximum_turns=20,
+        maximum_runtime_seconds=3600,
+        maximum_parallel_jobs=1,
+        active_since=now,
+        created_at=now,
+        updated_at=now,
+    )
+    result = store.create_retry_run(child, parent_run_id=parent.run_id)
+    assert result.run_id == child_id
+    assert store.get_lineage(parent.run_id)[0].run_id == child_id
+
+
+# ---------------------------------------------------------------------------
+# Storage: event log carries parent_run_id
+# ---------------------------------------------------------------------------
+
+
+def test_create_retry_run_event_contains_parent_run_id(tmp_path) -> None:
+    store = SqliteStore(str(tmp_path / 'db.sqlite'))
+    parent = _make_run(store, state=RunState.FAILED)
+    child_id = uuid4().hex
+    now = utc_now()
+    child = RunRecord(
+        run_id=child_id,
+        parent_run_id=parent.run_id,
+        objective=parent.objective,
+        state=RunState.CREATED,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/x',
+        honeydew_workspace='/x',
+        shared_artifacts_path='/x',
+        reports_path='/x',
+        maximum_turns=20,
+        maximum_runtime_seconds=3600,
+        maximum_parallel_jobs=1,
+        active_since=now,
+        created_at=now,
+        updated_at=now,
+    )
+    store.create_retry_run(child, parent_run_id=parent.run_id)
+    events = store.list_events(child_id)
+    created_events = [e for e in events if e.event_type == 'run.created']
+    assert created_events
+    assert created_events[0].payload.get('parent_run_id') == parent.run_id
+
+
+# ---------------------------------------------------------------------------
+# Discord: run.retry_created rendering
+# ---------------------------------------------------------------------------
+
+
+def test_discord_renders_retry_created_event(tmp_path) -> None:
+    from app.discord_adapter import DiscordRenderer
+    from app.schemas import EventRecord
+
+    store = SqliteStore(str(tmp_path / 'db.sqlite'))
+    parent = _make_run(store, state=RunState.FAILED)
+    child_id = uuid4().hex
+    now = utc_now()
+    child = RunRecord(
+        run_id=child_id,
+        parent_run_id=parent.run_id,
+        objective=parent.objective,
+        state=RunState.CREATED,
+        evaluation_contract_id='generic-research-v1',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/x',
+        honeydew_workspace='/x',
+        shared_artifacts_path='/x',
+        reports_path='/x',
+        maximum_turns=20,
+        maximum_runtime_seconds=3600,
+        maximum_parallel_jobs=1,
+        active_since=now,
+        created_at=now,
+        updated_at=now,
+    )
+    store.create_retry_run(child, parent_run_id=parent.run_id)
+    store.append_event(
+        run_id=child_id,
+        source='orchestrator',
+        event_type='run.retry_created',
+        payload={
+            'parent_run_id': parent.run_id,
+            'parent_state': 'FAILED',
+            'contract_digest': 'abc123',
+            'worktree_manifest_files': 3,
+        },
+    )
+    events = store.list_events(child_id)
+    retry_event = next(e for e in events if e.event_type == 'run.retry_created')
+
+    renderer = DiscordRenderer()
+    message = renderer.render(retry_event)
+    assert message is not None
+    assert 'Retry run created' in message.content
+    assert parent.run_id[:16] in message.content
+    assert 'FAILED' in message.content
+    assert '3' in message.content
+
+
+# ---------------------------------------------------------------------------
+# State machine: PREPARING -> HONEYDEW_REVIEWING is legal
+# ---------------------------------------------------------------------------
+
+
+def test_preparing_to_honeydew_reviewing_is_a_valid_transition() -> None:
+    from app.state_machine import validate_transition
+    validate_transition(RunState.PREPARING, RunState.HONEYDEW_REVIEWING)
+
+
+# ---------------------------------------------------------------------------
+# Schema: RunRecord carries parent_run_id; RunRetryRequest validates bounds
+# ---------------------------------------------------------------------------
+
+
+def test_run_record_defaults_parent_run_id_to_none() -> None:
+    now = utc_now()
+    record = RunRecord(
+        run_id='abc',
+        objective='x',
+        state=RunState.CREATED,
+        evaluation_contract_id='c',
+        evaluation_contract_version='1',
+        evaluation_contract_digest='a' * 64,
+        beaker_workspace='/x',
+        honeydew_workspace='/x',
+        shared_artifacts_path='/x',
+        reports_path='/x',
+        maximum_turns=1,
+        maximum_runtime_seconds=60,
+        maximum_parallel_jobs=1,
+        active_since=now,
+        created_at=now,
+        updated_at=now,
+    )
+    assert record.parent_run_id is None
+
+
+def test_run_retry_request_defaults_all_fields_to_none() -> None:
+    req = RunRetryRequest()
+    assert req.maximum_turns is None
+    assert req.maximum_runtime_seconds is None
+    assert req.maximum_parallel_jobs is None
+
+
+def test_run_retry_request_rejects_invalid_bounds() -> None:
+    import pydantic
+    with pytest.raises(pydantic.ValidationError):
+        RunRetryRequest(maximum_turns=0)
+    with pytest.raises(pydantic.ValidationError):
+        RunRetryRequest(maximum_runtime_seconds=30)


### PR DESCRIPTION
Closes #92

## Summary

- Adds `POST /runs/{run_id}/retry` — clones a FAILED/TIMED_OUT/CANCELLED run's Beaker worktree and approved protocol into a new child run, records lineage, and resumes at Honeydew methodology review
- `run_lineage` table (SQLite + Postgres) tracks parent→child relationships durably
- `clone_beaker_worktree` copies each file with sha256 integrity verification and rejects symlinks
- Recovery path fixed: a retry child crashed in `PREPARING` routes to `HONEYDEW_REVIEWING`, not `HONEYDEW_DRAFTING_PROTOCOL`
- Discord renders `run.retry_created` with parent run ID, terminal state, contract digest, and worktree file count

## Files changed

| File | Change |
|---|---|
| `app/schemas.py` | `RunRecord.parent_run_id`, `RunRetryRequest` model |
| `app/state_machine.py` | `PREPARING → HONEYDEW_REVIEWING` transition for retry fast-path |
| `app/storage.py` | `run_lineage` DDL, `create_retry_run()`, `get_lineage()` |
| `app/postgres_store.py` | Mirror of all storage.py additions |
| `app/workspaces.py` | `clone_beaker_worktree()` with sha256 check per file |
| `app/engine.py` | `retry_run()` method + recovery fix for retry children in PREPARING |
| `app/main.py` | `POST /runs/{run_id}/retry` (201 Created) |
| `app/discord_adapter.py` | `run.retry_created` event rendering |
| `tests/test_retry.py` | 23 new tests |

## Test plan

- [ ] All 168 tests pass (`pytest tests/ --ignore=tests/test_hermes_runtime.py`)
- [ ] Docs link check passes (`./scripts/check-before-push.sh --docs`)
- [ ] Invalid source states: active parent, COMPLETE parent, missing matrix action all rejected
- [ ] Idempotency: second retry attempt blocked when non-terminal child exists
- [ ] Restart recovery: child in PREPARING routes to HONEYDEW_REVIEWING not HONEYDEW_DRAFTING_PROTOCOL
- [ ] Execution approval and final-report approval gates remain mandatory in child run