### PR TITLE
Update contributor-facing project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Glasslab Cluster Config
 
-Glasslab is a runner-first ML research system built on a home Kubernetes lab.
+Glasslab is a Beaker/Honeydew research system and the lab platform that runs
+it. This repository contains the deterministic research control plane together
+with the Kubernetes, GPU, storage, registry, and model-serving configuration it
+depends on.
 
 The run fabric is deliberately narrow, but the product-level object is now an
 investigation. The goal is not general agent chat. The goal is:
@@ -29,49 +32,55 @@ investigation. The goal is not general agent chat. The goal is:
 
 Useful service buckets:
 
-- control plane:
+- current research control plane:
+  - `services/research-orchestrator`
   - `services/workflow-api`
   - `services/workflow-registry`
   - `services/evaluator`
   - `services/reporter`
-- command surface:
+- legacy or compatibility services:
   - `services/whatsapp-gateway`
   - `services/research-ingress`
   - `services/research-command-router`
-- bounded stage agents:
   - `services/intake-agent`
   - `services/interpretation-agent`
   - `services/assessment-agent`
   - `services/design-agent`
 
+The legacy services are retained for migration and historical reference. They
+are not the current research front door.
+
 ## Canonical Product Direction
 
-The first bounded Honeydew/Beaker research workflow is documented in
+The current bounded Honeydew/Beaker research workflow is documented in
 [`docs/research-orchestrator.md`](docs/research-orchestrator.md). It adds a
-durable outer research state machine around isolated OpenCode runtimes and the
+durable research workflow around isolated Hermes-backed runtimes and the
 existing bounded cluster-execution service. The Titanic stack remains legacy
-v1 reference material.
+v1 reference material; see [`docs/titanic-agent-stack.md`](docs/titanic-agent-stack.md).
 
 The current Discord and operator commands, arbitrary-task intake limits, and
 live progress are summarized in
 [`docs/research-orchestrator-command-surface.md`](docs/research-orchestrator-command-surface.md).
 
-The active product is the `glasslab-v2` research orchestrator.
+The active product is the Beaker/Honeydew research workflow on the
+`glasslab-v2` platform.
 
 The canonical human research path is:
 
 - Discord
 - `research-orchestrator`
-- isolated Honeydew and Beaker OpenCode runtimes
-- exo OpenAI-compatible model serving
+- isolated Hermes-backed Honeydew and Beaker runtimes
+- configured local OpenAI-compatible model serving
 - `workflow-api`
 - bounded Kubernetes Jobs
 
-OpenCode is the agents' inner tool-use runtime, not the durable workflow or
-human approval surface. `workflow-api` remains the canonical cluster execution
-control plane. WhatsApp, OpenClaw, and the older command-router path are
-compatibility or historical material rather than the current research front
-door.
+Hermes owns agent-level runtime behavior. Glasslab owns the durable workflow,
+state transitions, approvals, evaluation contracts, job policy, artifacts, and
+provenance. `workflow-api` remains the bounded cluster-execution control plane.
+The remaining orchestration boundary is tracked in
+[issue #154](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/154);
+authoritative invariants must remain deterministic and must not move into
+prompts or skills.
 
 ## Primary Operator Loop
 
@@ -89,7 +98,7 @@ question
 
 Discord is the primary human surface. The research orchestrator's database and
 append-only event log are authoritative; Discord is their operator-facing
-projection. OpenCode remains internal to Honeydew and Beaker.
+projection. Hermes remains internal to Honeydew and Beaker.
 
 ## Start Here
 
@@ -98,6 +107,10 @@ If you want the current source of truth:
 - [AGENTS.md](AGENTS.md) for the concise coding-agent and contributor handoff
 - [HANDOFF.md](HANDOFF.md) for the summarized current implementation checkpoint
 - [TODO.md](TODO.md) for the prioritized index into the GitHub Issues work queue
+- [Beaker/Honeydew delivery board](https://github.com/orgs/ccny-glasslab/projects/3)
+  for current Todo, In progress, and Done work
+- [Beaker/Honeydew roadmap and ownership](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/155)
+  for the active architecture boundary and contributor assignments
 - [CONTRIBUTING.md](CONTRIBUTING.md)
 - [docs/glasslab-v2/current/README.md](docs/glasslab-v2/current/README.md)
 - [docs/glasslab-v2/canonical-stack-2026-04.md](docs/glasslab-v2/canonical-stack-2026-04.md)
@@ -109,6 +122,7 @@ If you want the current source of truth:
 - [docs/glasslab-v2/ci-policy-2026-07.md](docs/glasslab-v2/ci-policy-2026-07.md)
 - [docs/glasslab-v2/command-surface-spec.md](docs/glasslab-v2/command-surface-spec.md)
 - [docs/research-orchestrator-command-surface.md](docs/research-orchestrator-command-surface.md)
+- [docs/research-orchestrator.md](docs/research-orchestrator.md)
 - [docs/glasslab-v2/router-and-backend-contract.md](docs/glasslab-v2/router-and-backend-contract.md)
 - [docs/glasslab-v2/deprecation-map-2026-04.md](docs/glasslab-v2/deprecation-map-2026-04.md)
 
@@ -117,6 +131,21 @@ If you are operating the lab:
 - `scripts/`
 - `docs/glasslab-v2/runbooks/`
 - `ansible/playbooks/`
+
+## Contributor Workflow
+
+1. Choose a `Todo` issue from the
+   [Beaker/Honeydew board](https://github.com/orgs/ccny-glasslab/projects/3).
+2. Read its acceptance criteria, assign yourself, and clarify scope in the
+   issue before starting.
+3. Create an issue-named branch and open one PR that references the issue.
+4. Keep state labels current: `state:in-progress`, `state:review`,
+   `state:blocked`, or `state:todo`.
+5. Treat CI as repository validation. Record live cluster checks and rollout
+   separately in the PR; CI does not prove deployment.
+
+Issues define desired outcomes, PRs define canonical implementations, and the
+durable run records define actual research state.
 
 ## Canonical Environment
 
@@ -142,10 +171,10 @@ So:
 
 Glasslab does not need more competing paths.
 
-It needs:
+The project needs:
 
-- one canonical command surface
+- one current Discord/operator surface
 - one canonical investigation record
-- one canonical record store
-- one canonical bounded experiment loop
-- one honest statement about what literature support currently is
+- one deterministic control plane
+- one bounded experiment loop
+- one honest distinction between current services and legacy material


### PR DESCRIPTION
## Summary

- update the root README to describe the current Beaker/Honeydew research system and lab platform
- document Hermes as the agent runtime and Glasslab as the deterministic control plane
- distinguish current services from legacy WhatsApp/OpenClaw/Titanic-era material
- link the authoritative delivery board and roadmap issue #155
- add the contributor workflow for Todo, In progress, review, blocked, and live-validation work

## Validation

- `git diff --check`
- `python3 scripts/check-doc-links.py`

No cluster, deployment, or runtime changes.