### PR TITLE
docs: reconcile authoritative docs with Hermes/Postgres/testing policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ The current human-facing research path is:
 ```text
 Discord
   -> research-orchestrator
-  -> isolated Honeydew and Beaker OpenCode runtimes
+  -> isolated Hermes-backed Honeydew and Beaker runtimes
   -> structured, policy-checked action requests
   -> workflow-api
   -> bounded Kubernetes Jobs
@@ -74,9 +74,15 @@ The responsibilities are deliberately separate:
 - **Discord** is an interface and transcript projection, not authoritative
   memory or state.
 
-Both agents currently use separate OpenCode processes and sessions against the
-exo OpenAI-compatible endpoint configured for the shared Qwen model. Their
-workspaces and OpenCode data are isolated per run and agent.
+Both agents run through separate Hermes gateway processes against the exo
+OpenAI-compatible endpoint configured for the shared Qwen model. Their
+workspaces and runtime data are isolated per run and agent. OpenCode remains
+installed only as a rollback runtime; it is selected only by setting
+`GLASSLAB_ORCHESTRATOR_AGENT_RUNTIME_BACKEND` back to `opencode`.
+
+Run state is stored in PostgreSQL in production, selected by
+`GLASSLAB_ORCHESTRATOR_STORE_BACKEND=postgres`. SQLite remains the local, test,
+and import-migration backend (`sqlite`).
 
 Primary code and deployment areas:
 
@@ -240,8 +246,10 @@ records applied immediately before every deletion.
 
 ## Development And Delivery
 
-Work on one branch per coherent change and open a pull request into protected
-`main`. Direct administrator pushes are for incident recovery only.
+Work on one branch per coherent change and open a feature pull request into
+`testing`. Promote `testing` to protected `main` only when the integration
+state is ready for production. Direct administrator pushes are for incident
+recovery only.
 
 Before pushing:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,10 @@ The default check mirrors the default CI signal:
 
 ## Pull Request Flow
 
-Create one branch for one coherent change and open a pull request into `main`.
-Continue pushing revisions to the same branch; GitHub updates the pull request
-automatically.
+Create one branch for one coherent change and open a pull request into
+`testing`. Continue pushing revisions to the same branch; GitHub updates the
+pull request automatically. Promote `testing` to `main` only when the
+integration state is ready for production.
 
 Start substantive work from a GitHub issue. The issue is the authoritative
 record for scope, status, acceptance criteria, dependencies, and discussion;
@@ -67,12 +68,15 @@ Use `Closes #<issue>` in the pull request when the merge fully resolves the
 work. If it only contributes to a larger issue, use `Refs #<issue>` and leave
 the remaining acceptance criteria visible on the issue.
 
-`main` is protected. A merge requires:
+`testing` and `main` are protected. A merge requires:
 
 - the always-running `Glasslab PR Gate` check
 - one approval from someone other than the author
 - all review conversations resolved
 - a current approval after material revisions
+
+`main` is the production branch and receives changes only by promoting
+reviewed `testing` state.
 
 Use squash merge, then delete the feature branch. Direct administrator pushes
 are an incident-recovery bypass, not a normal development path.
@@ -81,8 +85,8 @@ are an incident-recovery bypass, not a normal development path.
 
 Every pull request runs the four reusable CI lanes below. Their results are
 combined into the required `Glasslab PR Gate` check. Path-aware copies still
-run after relevant changes land on `main`, and compatibility tests remain
-manual.
+run after relevant changes land on `testing` or `main`, and compatibility
+tests remain manual.
 
 | Lane | Purpose |
 | --- | --- |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -5,12 +5,33 @@ Last updated: 2026-08-13
 This is the compact current-state checkpoint for switching human or coding
 agents. Read `AGENTS.md` first for stable rules, architecture, vocabulary,
 access paths, and live inspection commands. Read `TODO.md` for the prioritized
-work queue.
+work queue and `docs/glasslab-v2/current/README.md` for the current docs index.
+
+## State Layers
+
+Three distinct layers of truth, in decreasing authority:
+
+1. **Committed state** — the `ccny-glasslab/glasslab-cluster-config` repository
+   (`testing` is the shared integration branch; `main` is production).
+2. **Deployed state** — the image rolled out to the cluster, checked from the
+   provisioner and recorded here only when last verified.
+3. **Unverified live state** — anything not recently confirmed from `.44`; never
+   assert it as current.
+
+## Runtime And Storage
+
+- **Runtime:** Hermes is the selected agent runtime for Honeydew and Beaker.
+  OpenCode is installed only as a rollback runtime, selected only by setting
+  `GLASSLAB_ORCHESTRATOR_AGENT_RUNTIME_BACKEND` back to `opencode`.
+- **Store:** PostgreSQL is the production store
+  (`GLASSLAB_ORCHESTRATOR_STORE_BACKEND=postgres`). SQLite remains the local,
+  test, and import-migration backend.
 
 ## Live Infrastructure Facts
 
-The research orchestrator runs as a single pod on `node05`. Its state and
-per-run workspaces are on `glasslab-shared-artifacts`, backed by NFS at:
+The research orchestrator runs as a single pod on `node05`. Its per-run
+workspaces and durable artifacts are on `glasslab-shared-artifacts`, backed by
+NFS at:
 
 ```text
 192.168.1.207:/volume1/backup/glasslab-v2/shared-artifacts
@@ -19,47 +40,52 @@ per-run workspaces are on `glasslab-shared-artifacts`, backed by NFS at:
 Both agent runtimes point at the exo OpenAI-compatible service at
 `192.168.1.17:52415`. The cabled exo pair is `.17` and `.18`.
 
-OpenCode currently supplies the inner agent loop. Hermes Agent is being
-evaluated as a replacement for the OpenCode runtime/API integration and
-possibly the Discord transport. It is not approved as a replacement for the
-Glasslab state machine, evaluation contracts, artifact provenance, or
-`workflow-api`.
+## Deployed State (last verified 2026-08-13)
 
-## Latest Implemented Changes
+At the last check the deployed research-orchestrator image was commit `6ed16e8`
+(#141), running with `AGENT_RUNTIME_BACKEND=hermes` and
+`STORE_BACKEND=postgres`. Re-verify before relying on it:
 
-The deployed research-orchestrator image corresponds to commit `624de3d` and
-includes:
+```bash
+ssh glasslab-provisioner
+sudo -n env KUBECONFIG=/home/glasslab/.kube/config \
+  kubectl -n glasslab-v2 get deploy glasslab-research-orchestrator \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+```
 
-- a fresh methodology revision budget after new cluster evidence requires
-  repair
-- deterministic preflight rejection when workload source does not reference a
-  contract-required artifact
-- rejection of duplicated internal and outer multi-seed axes
-- prompt guidance distinguishing internal stability trials from independent
-  cluster repetitions
+## Committed State
 
-The orchestrator test suite passed 98 tests for that release. GitHub CI passed.
+Merged to `main`:
 
-PR #91 merged the root `AGENTS.md` and current Discord/operator documentation.
-This summarized handoff and the issue-backed work queue are follow-up changes
-on branch `docs/contributor-agent-handoff`; do not treat them as merged until
-their follow-up pull request is on `main`.
+- Hermes runtime for Honeydew and Beaker (#127); OpenCode retained as rollback.
+- PostgreSQL orchestrator store with a SQLite import tool (#130).
+- ccny GHCR image namespace cutover (#131, #132) and store migration tooling
+  (#133, #134, #135).
+- Hermes structured-output hardening (#142) and workflow-api live-status
+  degradation (#144).
 
-GitHub Issues are the authoritative work queue. The active backlog was reset
-on 2026-08-06: obsolete OpenClaw, WhatsApp, literature, and old autoresearch
-issues were closed with their history preserved. Current work is indexed in
-`TODO.md`.
+Merged to `testing` (not yet promoted to `main`):
 
-## Current Research Runs
+- read-only turn inspection (#147)
+- research runtime storage retention and cache cleanup (#148)
+- docs consolidation (#152)
+
+The orchestrator test suite passes 175 tests. GitHub CI is green for the
+committed branch.
+
+## Historical Research Runs
+
+These are past runs preserved for context; they do not describe current live
+state.
 
 ### Adult Income
 
 Run `cce710ceef97441685c777c8f19c767b` reached `COMPLETE`, including final
-acceptance. It is the current completed end-to-end compatibility example.
+acceptance. It was the first completed end-to-end compatibility example.
 
 ### Wine Clustering
 
-Run `39101d9c9d3d4753bcd74e93e6106819` is `TIMED_OUT` at turn 20.
+Run `39101d9c9d3d4753bcd74e93e6106819` ended `TIMED_OUT` at turn 20.
 
 What happened:
 
@@ -75,30 +101,13 @@ What happened:
 7. The overall run deadline expired before Honeydew could review the final
    proposal and expose execution approval.
 
-No corrected Wine job was submitted. The implementation and final proposal
-remain preserved in the timed-out run workspace. Terminal runs cannot currently
-be resumed through `/research-resume`.
+The preserved one-job Wine proposal is the intended first use of the
+terminal-checkpoint retry path (#92 / #145).
 
 ### Fashion-MNIST
 
-The compatibility task is preflight-ready but has not completed a live run.
-
-## Immediate Continuation
-
-Do not restart Wine from protocol drafting. First implement a controlled retry
-or clone-from-terminal-checkpoint operation that:
-
-- creates a new durable run and runtime budget
-- copies only approved protocol, task binding, worktree checkpoint, and latest
-  valid pending proposal
-- records lineage to the terminal parent run
-- invalidates stale pending actions
-- resumes at deterministic preflight and Honeydew methodology review
-- never silently submits a job or bypasses human approval
-
-Then use that path to continue the preserved one-job Wine proposal through
-Honeydew review, Discord execution approval, one corrected cluster job,
-evaluation, report, and final acceptance.
+The compatibility task was preflight-ready at the time but did not complete a
+live run (#101).
 
 ## Inspect Live State
 
@@ -122,7 +131,7 @@ ssh -L 18080:127.0.0.1:18080 glasslab-provisioner \
 Then:
 
 ```bash
-RUN=39101d9c9d3d4753bcd74e93e6106819
+RUN=<run-id>
 curl -fsS "http://127.0.0.1:18080/runs/$RUN" | jq
 curl -fsS "http://127.0.0.1:18080/runs/$RUN/events" | jq
 curl -fsS "http://127.0.0.1:18080/runs/$RUN/artifacts" | jq
@@ -137,23 +146,17 @@ Per-run files are available inside the orchestrator pod at:
 
 ## Known Risks
 
-- One orchestrator replica and SQLite WAL remain a scaling limitation.
+- One orchestrator replica remains a scaling limitation; PostgreSQL is the
+  production store but the single replica and Postgres availability are still
+  single points of the research path.
 - Agent turns can be slow against the shared exo model; large evidence bundles
   amplify the problem.
-- Terminal checkpoint retry is missing (tracked in #92).
-- OpenCode runtime caches consume substantial shared storage per run (tracked
-  in #99).
-- A generic arbitrary-dataset run has not yet completed end to end (tracked
-  in #98).
-- OpenCode's package/model cache is now shared across runs instead of
-  copied per run, and terminal-run scratch space (worktrees, runtime/) is
-  eligible for cleanup after `terminal_run_retention_days`; see
-  `services/research-orchestrator/scripts/cleanup-run-storage.py`. Hermes's
-  own runtime storage does not yet have the same cache-sharing treatment
-  (its on-disk layout under `HERMES_HOME` is not cleanly split into
-  cache/data/state the way OpenCode's is), only cleanup.
-- Discord has no explicit list or status slash command; the editable thread
-  message is the normal status surface.
+- Terminal checkpoint retry is implemented in #145 (open, targeting `testing`)
+  but not yet merged.
+- Hermes runtime storage does not yet have the same shared-cache treatment as
+  OpenCode; only per-run cleanup applies (see
+  `services/research-orchestrator/scripts/cleanup-run-storage.py`).
+- A generic arbitrary-dataset run has not yet completed end to end (#98).
 
 Update this file whenever the active deployment, current blocker, or next legal
 workflow step materially changes. Keep historical detail in dated docs or run

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,11 @@
 # Glasslab Work Queue
 
-Last reviewed: 2026-08-06
+Last reviewed: 2026-08-13
 
 GitHub Issues are the authoritative backlog. This file is a compact priority
 index for humans and coding agents arriving in the repository; it must not
-duplicate complete task specifications or maintain an independent status.
+duplicate complete task specifications or maintain an independent status. The
+authoritative roadmap, ownership, and current order of work are in issue #155.
 
 Current issues:
 
@@ -12,29 +13,17 @@ Current issues:
 - [ready work](https://github.com/ccny-glasslab/glasslab-cluster-config/issues?q=is%3Aissue%20state%3Aopen%20label%3Astate%3Aready)
 - [newcomer work](https://github.com/ccny-glasslab/glasslab-cluster-config/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
 
-## P0: Restore The End-To-End Research Loop
+## P0: Architecture And End-To-End Validation
 
-- [#104 Prevent missing Honeydew contract metadata from failing a run](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/104)
-- [#92 Add terminal research-run checkpoint retry](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/92)
-- [#100 Complete corrected Wine clustering run](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/100), blocked by #92
-
-## P1: Make Operation Observable And Faster
-
-- [#95 Expose structured research-run turn inspection](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/95)
-- [#94 Add Discord research run status and discovery commands](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/94)
-- [#93 Compact research-agent evidence prompts](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/93)
-- [#99 Add research runtime storage retention and cache cleanup](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/99)
-
-## P1: Validate General Research Tasks
-
+- [#154 Reassess ResearchOrchestrator responsibilities after Hermes migration](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/154)
+- [#92 Add terminal research-run checkpoint retry](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/92), implemented in #145 (draft)
 - [#98 Validate an arbitrary-dataset research workflow end to end](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/98)
+
+## P1: Research Validation And Operability
+
+- [#100 Complete corrected Wine clustering run](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/100), blocked by #92/#145
 - [#101 Complete Fashion-MNIST compatibility run](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/101)
-- [#96 Evaluate Hermes as a research-agent runtime adapter](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/96)
-
-## P2: Durability And Maintenance
-
-- [#97 Plan PostgreSQL migration for the research orchestrator](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/97)
-- [#102 Consolidate current docs and triage legacy issues](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/102)
+- [#93 Compact research-agent evidence prompts](https://github.com/ccny-glasslab/glasslab-cluster-config/issues/93)
 
 ## Maintenance Rule
 


### PR DESCRIPTION
Documentation-only consistency pass over the top-level contributor docs, aligned with issue #155 and the testing \u2192 main promotion policy.

## What changed

- **Hermes as runtime / OpenCode as rollback** — `AGENTS.md` and `HANDOFF.md` now state Hermes is the selected Honeydew/Beaker runtime and OpenCode is installed only as rollback (`GLASSLAB_ORCHESTRATOR_AGENT_RUNTIME_BACKEND`).
- **PostgreSQL as production / SQLite as fallback** — the same files now state PostgreSQL is the production store and SQLite is the local/test/import backend.
- **PRs into testing, not main** — `AGENTS.md` and `CONTRIBUTING.md` contributor instructions now say to open feature PRs into `testing` and promote to protected `main` only when ready.
- **Removed completed work from TODO.md** — closed items #94, #95, #99, #102, #104 and substantively-complete #96/#97 are removed; the queue is re-anchored on #155's current order of work (#154, #92/#145, #98, #100, #101, #93).
- **State layers** — `HANDOFF.md` now distinguishes committed / deployed (last verified 2026-08-13, image `6ed16e8`) / unverified live state, and updates the stale test count to 175.
- **Historical runs preserved without live assertion** — Adult/Wine/Fashion-MNIST details are moved under a "Historical Research Runs" heading.

## Verification

```
python3 scripts/check-doc-links.py
# Markdown links resolved successfully.

git diff --check
# no output (clean)
```

No application code, manifests, or live infrastructure were modified.