### PR TITLE
Preserve Hermes structured repair context

### DIFF
--- a/services/research-orchestrator/app/hermes_runtime.py
+++ b/services/research-orchestrator/app/hermes_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import json
 from pathlib import Path
+import re
 import secrets
 import socket
 import subprocess
@@ -16,7 +17,7 @@ from pydantic import ValidationError
 
 from .config import Settings
 from .opencode_runtime import AgentRuntime, RuntimeSession
-from .schemas import AgentName, AgentTurnResult
+from .schemas import AgentName, AgentTurnResult, TurnKind
 
 
 class HermesRuntimeError(RuntimeError):
@@ -45,8 +46,32 @@ class _HermesHandle:
     log_handle: Any
 
 
-def _structured_prompt(prompt: str) -> str:
-    schema = json.dumps(AgentTurnResult.model_json_schema(), sort_keys=True)
+def _required_turn_kind(prompt: str) -> TurnKind | None:
+    match = re.search(
+        r'Set the JSON `kind` field to exactly `([^`]+)`\.',
+        prompt,
+    )
+    if match is None:
+        return None
+    try:
+        return TurnKind(match.group(1))
+    except ValueError:
+        return None
+
+
+def _structured_prompt(
+    prompt: str,
+    *,
+    required_kind: TurnKind | None = None,
+) -> str:
+    schema_object = AgentTurnResult.model_json_schema()
+    if required_kind is not None:
+        schema_object['properties']['kind'] = {
+            'const': required_kind.value,
+            'title': 'Kind',
+            'type': 'string',
+        }
+    schema = json.dumps(schema_object, sort_keys=True)
     return (
         prompt
         + '\n\nReturn only one JSON object matching this schema after all '
@@ -55,7 +80,11 @@ def _structured_prompt(prompt: str) -> str:
     )
 
 
-def _decode_structured_output(output: Any) -> AgentTurnResult:
+def _decode_structured_output(
+    output: Any,
+    *,
+    required_kind: TurnKind | None = None,
+) -> AgentTurnResult:
     if not isinstance(output, str):
         raise HermesRuntimeError(
             'Hermes run output was not text',
@@ -73,7 +102,7 @@ def _decode_structured_output(output: Any) -> AgentTurnResult:
             failure_class='malformed_json',
         ) from exc
     try:
-        return AgentTurnResult.model_validate(payload)
+        result = AgentTurnResult.model_validate(payload)
     except ValidationError as exc:
         details = '; '.join(
             f"{'.'.join(str(part) for part in item['loc'])}: {item['msg']}"
@@ -83,6 +112,13 @@ def _decode_structured_output(output: Any) -> AgentTurnResult:
             f'Hermes structured output failed validation: {details}',
             failure_class='schema_invalid',
         ) from exc
+    if required_kind is not None and result.kind != required_kind:
+        raise HermesRuntimeError(
+            'Hermes structured output used kind '
+            f'{result.kind.value}; expected {required_kind.value}',
+            failure_class='wrong_kind',
+        )
+    return result
 
 
 class HermesProcessRuntime(AgentRuntime):
@@ -356,7 +392,11 @@ class HermesProcessRuntime(AgentRuntime):
             agent=agent,
             workspace=workspace,
         )
-        current_prompt = _structured_prompt(prompt)
+        required_kind = _required_turn_kind(prompt)
+        current_prompt = _structured_prompt(
+            prompt,
+            required_kind=required_kind,
+        )
         attempts = self.settings.hermes_structured_repair_attempts + 1
         for attempt in range(attempts):
             with self._client(handle) as client:
@@ -379,14 +419,29 @@ class HermesProcessRuntime(AgentRuntime):
             finally:
                 self._active_runs.pop(key, None)
             try:
-                return _decode_structured_output(output), hermes_run_id
-            except HermesRuntimeError:
+                return _decode_structured_output(
+                    output,
+                    required_kind=required_kind,
+                ), hermes_run_id
+            except HermesRuntimeError as exc:
                 if attempt + 1 >= attempts:
                     raise
+                previous_output = (
+                    output
+                    if isinstance(output, str)
+                    else json.dumps(output, sort_keys=True, default=str)
+                )
                 current_prompt = _structured_prompt(
-                    'Correct only the structured result from your previous '
-                    'completed turn. Do not repeat workspace work. Return a '
-                    'complete object matching the supplied schema.'
+                    'Correct only the structured result quoted below from '
+                    'your previous completed turn. Do not repeat workspace '
+                    'work. Preserve valid content, repair the identified '
+                    'error, and return a complete object matching the '
+                    'supplied schema.\n\n'
+                    f'Validation error: {exc}\n'
+                    'BEGIN PREVIOUS OUTPUT\n'
+                    f'{previous_output}\n'
+                    'END PREVIOUS OUTPUT',
+                    required_kind=required_kind,
                 )
         raise HermesRuntimeError('Hermes turn ended without a result')
 

--- a/services/research-orchestrator/tests/test_hermes_runtime.py
+++ b/services/research-orchestrator/tests/test_hermes_runtime.py
@@ -12,6 +12,7 @@ from app.hermes_runtime import (
     HermesProcessRuntime,
     _HermesHandle,
     _decode_structured_output,
+    _required_turn_kind,
 )
 from app.main import build_agent_runtime
 from app.opencode_runtime import OpenCodeProcessRuntime
@@ -220,3 +221,82 @@ def test_hermes_structured_output_failures_are_distinguishable() -> None:
             json.dumps({'kind': 'protocol_draft', 'summary': ''})
         )
     assert invalid.value.failure_class == 'schema_invalid'
+
+
+def test_hermes_repair_carries_rejected_output_and_required_kind(
+    tmp_path: Path,
+) -> None:
+    submitted_inputs: list[str] = []
+    outputs = [
+        json.dumps(
+            {
+                'kind': 'experiment_analysis',
+                'summary': 'The implementation plan was written.',
+                'produced_files': [
+                    {
+                        'path': 'implementation-plan.md',
+                        'purpose': 'implementation',
+                    }
+                ],
+            }
+        ),
+        json.dumps(
+            {
+                'kind': 'implementation_plan',
+                'summary': 'The implementation plan was written.',
+                'produced_files': [
+                    {
+                        'path': 'implementation-plan.md',
+                        'purpose': 'implementation',
+                    }
+                ],
+            }
+        ),
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == 'POST' and request.url.path == '/v1/runs':
+            submitted_inputs.append(json.loads(request.content)['input'])
+            return httpx.Response(
+                200,
+                json={'run_id': f'hermes-run-{len(submitted_inputs)}'},
+            )
+        if request.method == 'GET' and request.url.path.startswith('/v1/runs/'):
+            run_number = int(request.url.path.rsplit('-', 1)[1])
+            return httpx.Response(
+                200,
+                json={'status': 'completed', 'output': outputs[run_number - 1]},
+            )
+        raise AssertionError(f'unexpected request: {request.method} {request.url}')
+
+    runtime = HermesProcessRuntime(
+        Settings(
+            hermes_poll_interval_seconds=0,
+            hermes_structured_repair_attempts=1,
+        ),
+        transport=httpx.MockTransport(handler),
+    )
+    handle = _handle(tmp_path)
+    runtime._start_process = lambda **_kwargs: handle  # type: ignore[method-assign]
+
+    result, _ = runtime.run_turn(
+        run_id='run-test',
+        agent=AgentName.HONEYDEW,
+        workspace=handle.workspace,
+        session_id='glasslab-honeydew-run-test',
+        prompt=(
+            'Write implementation-plan.md.\n\n'
+            'AUTHORITATIVE STRUCTURED OUTPUT CONTRACT:\n'
+            '- Set the JSON `kind` field to exactly `implementation_plan`.\n'
+        ),
+    )
+
+    assert result.kind == TurnKind.IMPLEMENTATION_PLAN
+    assert len(submitted_inputs) == 2
+    assert outputs[0] in submitted_inputs[1]
+    assert 'Validation error: Hermes structured output used kind' in (
+        submitted_inputs[1]
+    )
+    assert '"const": "implementation_plan"' in submitted_inputs[0]
+    assert '"const": "implementation_plan"' in submitted_inputs[1]
+    assert _required_turn_kind(submitted_inputs[0]) == TurnKind.IMPLEMENTATION_PLAN


### PR DESCRIPTION
## Summary
- constrain Hermes structured-output schemas to the workflow-selected turn kind
- validate the returned kind inside the runtime
- include the rejected output and validation error in structured repair requests

## Root cause
Hermes started repair as a separate run without quoting the rejected result. The repair model therefore reported that no prior result was available and defaulted to `experiment_analysis`, even after Beaker had written the required implementation plan.

## Validation
- focused Hermes/workflow tests: 48 passed
- full research-orchestrator suite: 224 passed, 7 skipped